### PR TITLE
Fix a timestamp rounding issue in `FFmpegFrameGrabber` that causes `setF...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-
+ * Fix a timestamp rounding issue in `FFmpegFrameGrabber` that causes `setFrameNumber()` to sometimes pick the wrong frame if FPS is not a proper divisor of 1000000 ([issue #5](https://github.com/bytedeco/javacv/issues/5))
  * Increase the flexibility of the `pom.xml` file by making it possible to specify a custom version of JavaCPP
  * Add missing dependencies for JogAmp in the `pom.xml` file ([issue #2](https://github.com/bytedeco/javacv/issues/2))
  * Add new `OpenCVFaceRecognizer` sample, thanks to Petter Christian Bjelland

--- a/src/main/java/org/bytedeco/javacv/FFmpegFrameGrabber.java
+++ b/src/main/java/org/bytedeco/javacv/FFmpegFrameGrabber.java
@@ -287,10 +287,16 @@ public class FFmpegFrameGrabber extends FrameGrabber {
                 pkt2.size(0);
                 av_free_packet(pkt);
             }
-            while (this.timestamp > timestamp && grabFrame(false) != null) {
+            /* comparing to timestamp +/- 1 avoids rouding issues for framerates
+               which are no proper divisors of 1000000, e.g. where
+               av_frame_get_best_effort_timestamp in grabFrame sets this.timestamp
+               to ...666 and the given timestamp has been rounded to ...667
+               (or vice versa)
+            */
+            while (this.timestamp > timestamp + 1 && grabFrame(false) != null) {
                 // flush frames if seeking backwards
             }
-            while (this.timestamp < timestamp && grabFrame(false) != null) {
+            while (this.timestamp < timestamp - 1 && grabFrame(false) != null) {
                 // decode up to the desired frame
             }
             if (video_c != null) {


### PR DESCRIPTION
...rameNumber()` to sometimes pick the wrong frame if FPS is not a proper divisor of 1000000 (issue #5)
