### PR TITLE
FFmpegFrameGrabber: Makes public the method grabFrame(boolean processImage, boolean doAud…

### DIFF
--- a/src/main/java/org/bytedeco/javacv/FFmpegFrameGrabber.java
+++ b/src/main/java/org/bytedeco/javacv/FFmpegFrameGrabber.java
@@ -615,7 +615,7 @@ public class FFmpegFrameGrabber extends FrameGrabber {
     public Frame grabKeyFrame() throws Exception {
         return grabFrame(true, false, true);
     }
-    private Frame grabFrame(boolean processImage, boolean doAudio, boolean keyFrames) throws Exception {
+    public Frame grabFrame(boolean processImage, boolean doAudio, boolean keyFrames) throws Exception {
         if (oc == null || oc.isNull()) {
             throw new Exception("Could not grab: No AVFormatContext. (Has start() been called?)");
         }


### PR DESCRIPTION
…io, boolean keyFrames). Was private and the other helper methods didn't allow grabFrame(true, false, false).