### PR TITLE
convert Object to FrameRecorder at return statement (public static Fr…

### DIFF
--- a/src/main/java/org/bytedeco/javacv/FrameRecorder.java
+++ b/src/main/java/org/bytedeco/javacv/FrameRecorder.java
@@ -72,7 +72,7 @@ public abstract class FrameRecorder {
     public static FrameRecorder create(Class<? extends FrameRecorder> c, Class p, Object o, int w, int h) throws Exception {
         Throwable cause = null;
         try {
-            return c.getConstructor(p, int.class, int.class).newInstance(o, w, h);
+            return (FrameRecoder)c.getConstructor(p, int.class, int.class).newInstance(o, w, h);
         } catch (InstantiationException ex) {
             cause = ex;
         } catch (IllegalAccessException ex) {


### PR DESCRIPTION
…ameRecorder create(....))

The return statement now consists of a Object instance, which can not be returned by this function.
Therefore I propose to add a cast to the return statement so that the Object is converted to a FrameRecorder instance before it is returned.