### PR TITLE
Fix IPCameraFrameGrabber.stop check for null

### DIFF
--- a/src/main/java/org/bytedeco/javacv/IPCameraFrameGrabber.java
+++ b/src/main/java/org/bytedeco/javacv/IPCameraFrameGrabber.java
@@ -74,7 +74,7 @@ public class IPCameraFrameGrabber extends FrameGrabber {
     }
 
     @Override
-    public void start() {
+    public void start() throws Exception {
 
         try {
             connection = url.openConnection();

--- a/src/main/java/org/bytedeco/javacv/IPCameraFrameGrabber.java
+++ b/src/main/java/org/bytedeco/javacv/IPCameraFrameGrabber.java
@@ -91,7 +91,7 @@ public class IPCameraFrameGrabber extends FrameGrabber {
             }
             input = connection.getInputStream();
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new Exception(e.getMessage(), e);
         }
     }
 
@@ -102,7 +102,7 @@ public class IPCameraFrameGrabber extends FrameGrabber {
                 input.close();
                 input = null;
                 connection = null;
-                url = null;
+                // Don't set the url to null, it may be needed to restart this object
                 if (decoded != null){
                     cvReleaseImage(decoded);
                 }

--- a/src/main/java/org/bytedeco/javacv/IPCameraFrameGrabber.java
+++ b/src/main/java/org/bytedeco/javacv/IPCameraFrameGrabber.java
@@ -97,16 +97,18 @@ public class IPCameraFrameGrabber extends FrameGrabber {
 
     @Override
     public void stop() throws Exception {
-        try {
-            input.close();
-            input = null;
-            connection = null;
-            url = null;
-            if (decoded != null){
-                cvReleaseImage(decoded);
+        if (input != null) {
+            try {
+                input.close();
+                input = null;
+                connection = null;
+                url = null;
+                if (decoded != null){
+                    cvReleaseImage(decoded);
+                }
+            } catch (IOException e) {
+                throw new Exception(e.getMessage(), e);
             }
-        } catch (IOException e) {
-            throw new Exception(e.getMessage(), e);
         }
     }
 


### PR DESCRIPTION
This makes it possible to call `restart` on this frame grabber without throwing a NullPointerException.

Closes #299