### PR TITLE
Cleans up IPFrameGrabber

### DIFF
--- a/src/main/java/org/bytedeco/javacv/IPCameraFrameGrabber.java
+++ b/src/main/java/org/bytedeco/javacv/IPCameraFrameGrabber.java
@@ -22,19 +22,19 @@
 
 package org.bytedeco.javacv;
 
+import org.bytedeco.javacpp.BytePointer;
+import org.bytedeco.javacpp.Loader;
+
+import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.EOFException;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
-import java.util.List;
-import java.util.Map;
-import javax.imageio.ImageIO;
-import org.bytedeco.javacpp.BytePointer;
-import org.bytedeco.javacpp.Loader;
+import java.util.concurrent.TimeUnit;
 
 import static org.bytedeco.javacpp.opencv_core.*;
 import static org.bytedeco.javacpp.opencv_imgcodecs.*;
@@ -49,6 +49,7 @@ public class IPCameraFrameGrabber extends FrameGrabber {
      */
 
     private static Exception loadingException = null;
+
     public static void tryLoad() throws Exception {
         if (loadingException != null) {
             throw loadingException;
@@ -61,35 +62,75 @@ public class IPCameraFrameGrabber extends FrameGrabber {
         }
     }
 
-    private URL url;
-    private URLConnection connection;
-    private InputStream input;
-    private Map<String, List<String>> headerfields;
-    private String boundryKey;
+    private final FrameConverter converter = new OpenCVFrameConverter.ToIplImage();
+    private final URL url;
+    private final int connectionTimeout;
+    private final int readTimeout;
+    private DataInputStream input;
+    private byte[] pixelBuffer = new byte[1024];
     private IplImage decoded = null;
-    private FrameConverter converter = new OpenCVFrameConverter.ToIplImage();
 
+    /**
+     * @param url          The URL to create the camera connection with.
+     * @param startTimeout How long should this wait on the connection while trying to {@link #start()} before
+     *                     timing out.
+     *                     If this value is less than zero it will be ignored.
+     *                     {@link URLConnection#setConnectTimeout(int)}
+     * @param grabTimeout  How long should grab wait while reading the connection before timing out.
+     *                     If this value is less than zero it will be ignored.
+     *                     {@link URLConnection#setReadTimeout(int)}
+     * @param timeUnit     The time unit to use for the connection and read timeout.
+     *                     If this value is null then the start timeout and grab timeout will be ignored.
+     */
+    public IPCameraFrameGrabber(URL url, int startTimeout, int grabTimeout, TimeUnit timeUnit) {
+        super(); // Always good practice to do this
+        if (url == null) {
+            throw new IllegalArgumentException("URL can not be null");
+        }
+        this.url = url;
+        if (timeUnit == null) {
+            this.connectionTimeout = toIntExact(TimeUnit.MILLISECONDS.convert(startTimeout, timeUnit));
+            this.readTimeout = toIntExact(TimeUnit.MILLISECONDS.convert(grabTimeout, timeUnit));
+        } else {
+            this.connectionTimeout = -1;
+            this.readTimeout = -1;
+        }
+    }
+
+    public IPCameraFrameGrabber(String urlstr, int connectionTimeout, int readTimeout, TimeUnit timeUnit) throws MalformedURLException {
+        this(new URL(urlstr), connectionTimeout, readTimeout, timeUnit);
+    }
+
+    /**
+     * @param urlstr A string to be used to create the URL.
+     * @throws MalformedURLException if the urlstr is a malformed URL
+     * @gi By not setting the connection timeout and the read timeout if your network ever crashes
+     * then {@link #start()} or {@link #grab()} can hang for upwards of 45 to 60 seconds before failing.
+     * You should always explicitly set the connectionTimeout and readTimeout so that your application can
+     * respond appropriately to a loss or failure to connect.
+     */
+    @Deprecated
     public IPCameraFrameGrabber(String urlstr) throws MalformedURLException {
-        url = new URL(urlstr);
+        this(new URL(urlstr), -1, -1, null);
     }
 
     @Override
     public void start() throws Exception {
-
         try {
-            connection = url.openConnection();
-            headerfields = connection.getHeaderFields();
-            if (headerfields.containsKey("Content-Type")) {
-                List<String> ct = headerfields.get("Content-Type");
-                for (int i = 0; i < ct.size(); ++i) {
-                    String key = ct.get(i);
-                    int j = key.indexOf("boundary=");
-                    if (j != -1) {
-                        boundryKey = key.substring(j + 9); // FIXME << fragile
-                    }
-                }
+            /*
+             * We don't need to keep a reference to the connection
+             * after it is opened in the parent class.
+             * It never uses it outside of start.
+             */
+            final URLConnection connection = url.openConnection();
+            // If the class was initialized with timeout values then configure those
+            if (connectionTimeout >= 0) {
+                connection.setConnectTimeout(connectionTimeout);
             }
-            input = connection.getInputStream();
+            if (readTimeout >= 0) {
+                connection.setReadTimeout(readTimeout);
+            }
+            input = new DataInputStream(connection.getInputStream());
         } catch (IOException e) {
             throw new Exception(e.getMessage(), e);
         }
@@ -100,14 +141,13 @@ public class IPCameraFrameGrabber extends FrameGrabber {
         if (input != null) {
             try {
                 input.close();
-                input = null;
-                connection = null;
-                // Don't set the url to null, it may be needed to restart this object
-                if (decoded != null){
-                    cvReleaseImage(decoded);
-                }
             } catch (IOException e) {
                 throw new Exception(e.getMessage(), e);
+            } finally {
+                // Close may have failed but there's really nothing we can do about it at this point
+                input = null;
+                // Don't set the url to null, it may be needed to restart this object
+                releaseDecoded();
             }
         }
     }
@@ -119,11 +159,9 @@ public class IPCameraFrameGrabber extends FrameGrabber {
     @Override
     public Frame grab() throws Exception {
         try {
-            byte[] b = readImage();
-            CvMat mat = cvMat(1, b.length, CV_8UC1, new BytePointer(b));
-            if (decoded != null){
-                cvReleaseImage(decoded);
-            }
+            final byte[] b = readImage();
+            final CvMat mat = cvMat(1, b.length, CV_8UC1, new BytePointer(b));
+            releaseDecoded();
             return converter.convert(decoded = cvDecodeImage(mat));
         } catch (IOException e) {
             throw new Exception(e.getMessage(), e);
@@ -135,13 +173,20 @@ public class IPCameraFrameGrabber extends FrameGrabber {
         return bi;
     }
 
-    byte[] readImage() throws IOException {
-        byte[] buffer = new byte[4096];// MTU or JPG Frame Size?
-        int n = -1;
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    /**
+     * Ensures that if the decoded image is not null that it gets released and set to null.
+     * If the image was not set to null then trying to release a null pointer will cause  a
+     * segfault.
+     */
+    private void releaseDecoded() {
+        if (decoded != null) {
+            cvReleaseImage(decoded);
+            decoded = null;
+        }
+    }
 
-        StringBuffer sb = new StringBuffer();
-        int total = 0;
+    private byte[] readImage() throws IOException {
+        final StringBuffer sb = new StringBuffer();
         int c;
         // read http subheader
         while ((c = input.read()) != -1) {
@@ -160,52 +205,71 @@ public class IPCameraFrameGrabber extends FrameGrabber {
             }
         }
         // find embedded jpeg in stream
-        String subheader = sb.toString();
+        final String subheader = sb.toString();
         //log.debug(subheader);
-        int contentLength = -1;
-        // if (boundryKey == null)
-        // {
+
         // Yay! - server was nice and sent content length
         int c0 = subheader.indexOf("Content-Length: ");
-        int c1 = subheader.indexOf('\r', c0);
+        final int c1 = subheader.indexOf('\r', c0);
 
         if (c0 < 0) {
             //log.info("no content length returning null");
-            return null;
+            throw new EOFException("The camera stream ended unexpectedly");
         }
 
         c0 += 16;
-        contentLength = Integer.parseInt(subheader.substring(c0, c1).trim());
+        final int contentLength = Integer.parseInt(subheader.substring(c0, c1).trim());
         //log.debug("Content-Length: " + contentLength);
 
         // adaptive size - careful - don't want a 2G jpeg
-        if (contentLength > buffer.length) {
-            buffer = new byte[contentLength];
-        }
+        ensureBufferCapacity(contentLength);
 
-        n = -1;
-        total = 0;
-        while ((n = input.read(buffer, 0, contentLength - total)) != -1) {
-            total += n;
-            baos.write(buffer, 0, n);
-
-            if (total == contentLength) {
-                break;
-            }
-        }
-
-        baos.flush();
-
+        input.readFully(pixelBuffer, 0, contentLength);
         input.read();// \r
         input.read();// \n
         input.read();// \r
         input.read();// \n
 
-        return baos.toByteArray();
+        return pixelBuffer;
     }
 
     @Override
     public void release() throws Exception {
+    }
+
+    /**
+     * Grow the pixel buffer if necessary.  Using this method instead of allocating a new buffer every time a frame
+     * is grabbed improves performance by reducing the frequency of garbage collections.  In a simple test, the
+     * original version of IPCameraFrameGrabber that allocated a 4096 element byte array for every read
+     * caused about 200MB of allocations within 13 seconds.  In this version, almost no additional heap space
+     * is typically allocated per frame.
+     */
+    private void ensureBufferCapacity(int desiredCapacity) {
+        int capacity = pixelBuffer.length;
+
+        while (capacity < desiredCapacity) {
+            capacity *= 2;
+        }
+
+        if (capacity > pixelBuffer.length) {
+            pixelBuffer = new byte[capacity];
+        }
+    }
+
+    /**
+     * Returns the value of the {@code long} argument;
+     * throwing an exception if the value overflows an {@code int}.
+     *
+     * @param value the long value
+     * @return the argument as an int
+     * @throws ArithmeticException if the {@code argument} overflows an int
+     * @see <a href="https://docs.oracle.com/javase/8/docs/api/java/lang/Math.html#toIntExact-long-">Java 8 Implementation</a>
+     */
+    private static int toIntExact(long value) {
+        if ((int) value != value) {
+            throw new ArithmeticException("integer overflow");
+        }
+        return (int) value;
     }
 
 }


### PR DESCRIPTION
 - The IPFrameGrabber was allocating new memory on each readImage
this was allocating memory unnessasaraly on the heap. Now it only
allocates new memory if the image size changes.
 - The constructor now allows for configuring the connection and
read timeouts for the URLConnection.
 - If there is an unexpected end of the stream read image throws
an EOFException instead of returning null.
 - Reading data now uses a DataInputStream straight into the pixel
buffer.
 - Removes a bunch of unessasary header parsing in start.
 - Makes URL and FrameConverter final

Closes #312
Closes #322