### PR TITLE
Adds documentation to explain functionality

### DIFF
--- a/src/main/java/org/bytedeco/javacv/FrameGrabber.java
+++ b/src/main/java/org/bytedeco/javacv/FrameGrabber.java
@@ -63,7 +63,7 @@ public abstract class FrameGrabber {
                     if (s.length > 0) {
                         mayContainCameras = true;
                     }
-                } catch (Throwable t) { 
+                } catch (Throwable t) {
                     if (t.getCause() instanceof UnsupportedOperationException) {
                         mayContainCameras = true;
                     }
@@ -421,6 +421,25 @@ public abstract class FrameGrabber {
     public abstract void start() throws Exception;
     public abstract void stop() throws Exception;
     public abstract void trigger() throws Exception;
+
+    /**
+     * Each call to grab stores the new image in the memory address for the previously returned frame. <br/>
+     * IE.<br/>
+     * <code>
+     * grabber.grab() == grabber.grab()
+     * </code>
+     * <br/>
+     * This means that if you need to cache images returned from grab you should {@link Frame#clone()} the
+     * returned frame as the next call to grab will overwrite your existing image's memory.
+     * <br/>
+     * <b>Why?</b><br/>
+     * Using this method instead of allocating a new buffer every time a frame
+     * is grabbed improves performance by reducing the frequency of garbage collections.
+     * Almost no additional heap space is typically allocated per frame.
+     *
+     * @return The frame returned from the grabber
+     * @throws Exception If there is a problem grabbing the frame.
+     */
     public abstract Frame grab() throws Exception;
     public Frame grabFrame() throws Exception { return grab(); }
     public abstract void release() throws Exception;

--- a/src/main/java/org/bytedeco/javacv/IPCameraFrameGrabber.java
+++ b/src/main/java/org/bytedeco/javacv/IPCameraFrameGrabber.java
@@ -104,7 +104,7 @@ public class IPCameraFrameGrabber extends FrameGrabber {
     /**
      * @param urlstr A string to be used to create the URL.
      * @throws MalformedURLException if the urlstr is a malformed URL
-     * @gi By not setting the connection timeout and the read timeout if your network ever crashes
+     * @deprecated By not setting the connection timeout and the read timeout if your network ever crashes
      * then {@link #start()} or {@link #grab()} can hang for upwards of 45 to 60 seconds before failing.
      * You should always explicitly set the connectionTimeout and readTimeout so that your application can
      * respond appropriately to a loss or failure to connect.


### PR DESCRIPTION
 - Somehow the @deprecated got removed from the
IPCameraFrameGrabber.
 - Adds documentation to FrameGrabber#grab to help clarify how
memory is managed internally.