### PR TITLE
libdc1394 not matching the latest.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
     <dependency>
       <groupId>org.bytedeco.javacpp-presets</groupId>
       <artifactId>libdc1394</artifactId>
-      <version>2.2.4-${javacpp.version}</version>
+      <version>2.2.5-${javacpp.version}</version>
     </dependency>
     <dependency>
       <groupId>org.bytedeco.javacpp-presets</groupId>


### PR DESCRIPTION
Hello, 

I just had compilation issues, it seems that libdc1394 was not matching the one of javacpp-preset 's master branch. 

Cheers, 
Jeremy.