### PR TITLE
Add OpenCVFrameGrabber support for setting capture format (such as MJPG)

### DIFF
--- a/src/main/java/org/bytedeco/javacv/OpenCVFrameGrabber.java
+++ b/src/main/java/org/bytedeco/javacv/OpenCVFrameGrabber.java
@@ -176,8 +176,13 @@ public class OpenCVFrameGrabber extends FrameGrabber {
             capture = new VideoCapture(deviceNumber);
         }
 
-        if (format != null && format.equals("MJPEG")) {
-            capture.set(CV_CAP_PROP_FOURCC, CV_FOURCC((byte)'M', (byte)'J', (byte)'P', (byte)'G'));
+        if (format != null && format.length() >= 4) {
+            format = format.toUpperCase();
+            byte cc0 = (byte)format.charAt(0);
+            byte cc1 = (byte)format.charAt(1);
+            byte cc2 = (byte)format.charAt(2);
+            byte cc3 = (byte)format.charAt(3);
+            capture.set(CV_CAP_PROP_FOURCC, CV_FOURCC(cc0, cc1, cc2, cc3));
         }
 
         if (imageWidth > 0) {

--- a/src/main/java/org/bytedeco/javacv/OpenCVFrameGrabber.java
+++ b/src/main/java/org/bytedeco/javacv/OpenCVFrameGrabber.java
@@ -175,6 +175,11 @@ public class OpenCVFrameGrabber extends FrameGrabber {
         } else {
             capture = new VideoCapture(deviceNumber);
         }
+
+        if (format != null && format.equals("MJPEG")) {
+            capture.set(CV_CAP_PROP_FOURCC, CV_FOURCC((byte)'M', (byte)'J', (byte)'P', (byte)'G'));
+        }
+
         if (imageWidth > 0) {
             if (!capture.set(CV_CAP_PROP_FRAME_WIDTH, imageWidth)) {
                 capture.set(CV_CAP_PROP_MODE, imageWidth); // ??


### PR DESCRIPTION
Fixes #650

Adds the ability to OpenCVFrameGrabber to set the capture format to MJPEG, which (if supported by the webcam) provides much better performance than the default YUY2.