### PR TITLE
Fix FFmpegFrameGrabber to properly seek/skip the data inside custom InputStream

### DIFF
--- a/src/main/java/org/bytedeco/javacv/FFmpegFrameGrabber.java
+++ b/src/main/java/org/bytedeco/javacv/FFmpegFrameGrabber.java
@@ -524,7 +524,7 @@ public class FFmpegFrameGrabber extends FrameGrabber {
                 seekCallback = new SeekCallback();
             }
             if (!inputStream.markSupported()) {
-                inputStream = new BufferedInputStream(inputStream, Integer.MAX_VALUE - 8);
+                inputStream = new BufferedInputStream(inputStream);
             }
             inputStream.mark(Integer.MAX_VALUE - 8); // so that the whole input stream is seekable
             oc = avformat_alloc_context();


### PR DESCRIPTION
The code previously did not respect `InputStream.skip()` return value. It leads to wrong seek result because the data might not be skipped to the desired offset.

It also assumed that the maximum input stream size is 1MB which might not be the case for bigger file.  The problem arises when that the data after 1MB offset is read and the mark position is reset. It leads to `InputStream.reset()` not reset to the start of the stream as expected.

This merge requests 
* Respect the InputStream.skip() return value
* Assume the input stream maximum size is at integer maximum.