### PR TITLE
Fixed output streams leaking in FFmpegFrameRecorder

### DIFF
--- a/src/main/java/org/bytedeco/javacv/FFmpegFrameRecorder.java
+++ b/src/main/java/org/bytedeco/javacv/FFmpegFrameRecorder.java
@@ -245,6 +245,25 @@ public class FFmpegFrameRecorder extends FrameRecorder {
                 oc.metadata(null);
             }
 
+            if (outputStream != null) {
+                try {
+                    outputStream.close();
+                } catch (IOException ex) {
+                    throw new Exception("Error on OutputStream.close(): ", ex);
+                } finally {
+                    outputStream = null;
+                    outputStreams.remove(oc);
+                    if (avio != null) {
+                        if (avio.buffer() != null) {
+                            av_free(avio.buffer());
+                            avio.buffer(null);
+                        }
+                        av_free(avio);
+                        avio = null;
+                    }
+                }
+            }
+
             /* free the stream */
             av_free(oc);
             oc = null;
@@ -258,25 +277,6 @@ public class FFmpegFrameRecorder extends FrameRecorder {
         if (samples_convert_ctx != null) {
             swr_free(samples_convert_ctx);
             samples_convert_ctx = null;
-        }
-
-        if (outputStream != null) {
-            try {
-                outputStream.close();
-            } catch (IOException ex) {
-                throw new Exception("Error on OutputStream.close(): ", ex);
-            } finally {
-                outputStream = null;
-                outputStreams.remove(oc);
-                if (avio != null) {
-                    if (avio.buffer() != null) {
-                        av_free(avio.buffer());
-                        avio.buffer(null);
-                    }
-                    av_free(avio);
-                    avio = null;
-                }
-            }
         }
     }
     @Override protected void finalize() throws Throwable {

--- a/src/main/java/org/bytedeco/javacv/FFmpegFrameRecorder.java
+++ b/src/main/java/org/bytedeco/javacv/FFmpegFrameRecorder.java
@@ -226,6 +226,7 @@ public class FFmpegFrameRecorder extends FrameRecorder {
         audio_st = null;
         filename = null;
 
+        AVFormatContext outputStreamKey = oc;
         if (oc != null && !oc.isNull()) {
             if (outputStream == null && (oformat.flags() & AVFMT_NOFILE) == 0) {
                 /* close the output file */
@@ -245,25 +246,6 @@ public class FFmpegFrameRecorder extends FrameRecorder {
                 oc.metadata(null);
             }
 
-            if (outputStream != null) {
-                try {
-                    outputStream.close();
-                } catch (IOException ex) {
-                    throw new Exception("Error on OutputStream.close(): ", ex);
-                } finally {
-                    outputStream = null;
-                    outputStreams.remove(oc);
-                    if (avio != null) {
-                        if (avio.buffer() != null) {
-                            av_free(avio.buffer());
-                            avio.buffer(null);
-                        }
-                        av_free(avio);
-                        avio = null;
-                    }
-                }
-            }
-
             /* free the stream */
             av_free(oc);
             oc = null;
@@ -277,6 +259,25 @@ public class FFmpegFrameRecorder extends FrameRecorder {
         if (samples_convert_ctx != null) {
             swr_free(samples_convert_ctx);
             samples_convert_ctx = null;
+        }
+
+        if (outputStream != null) {
+            try {
+                outputStream.close();
+            } catch (IOException ex) {
+                throw new Exception("Error on OutputStream.close(): ", ex);
+            } finally {
+                outputStream = null;
+                outputStreams.remove(outputStreamKey);
+                if (avio != null) {
+                    if (avio.buffer() != null) {
+                        av_free(avio.buffer());
+                        avio.buffer(null);
+                    }
+                    av_free(avio);
+                    avio = null;
+                }
+            }
         }
     }
     @Override protected void finalize() throws Throwable {


### PR DESCRIPTION
`outputStreams.remove(oc);` was called after `oc = null;`, so static outputStreams kept reference to outputStream forever. It's not a big problem in case of file streams, but it becomes a memory leak in case of `ByteArrayOutputStream`.