### PR TITLE
Please see issue #843 - Improve readme md

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ And by placing the source code above in `src/main/java/Demo.java`, we can use th
  $ mvn compile exec:java -Dexec.mainClass=Demo
 ```
 
-Note: In case of errors, please make sure that the artifact id in the `pom.xml` reads `javacv-platform`, not e.g. `javacv` only. The artifact `javacv-platform` contains all the necessary binary dependencies
+Note: In case of errors, please make sure that the artifact id in the `pom.xml` reads `javacv-platform`, not e.g. `javacv` only. The artifact `javacv-platform` contains all the necessary binary dependencies.
 
 Build Instructions
 ------------------

--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ And by placing the source code above in `src/main/java/Demo.java`, we can use th
  $ mvn compile exec:java -Dexec.mainClass=Demo
 ```
 
+Note: In case of errors, please make sure that the artifact id in the `pom.xml` reads `javacv-platform`, not e.g. `javacv` only. The artifact `javacv-platform` contains all the necessary binary dependencies
 
 Build Instructions
 ------------------

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ And by placing the source code above in `src/main/java/Demo.java`, we can use th
  $ mvn compile exec:java -Dexec.mainClass=Demo
 ```
 
-Note: In case of errors, please make sure that the artifact id in the `pom.xml` reads `javacv-platform`, not e.g. `javacv` only. The artifact `javacv-platform` contains all the necessary binary dependencies.
+**Note**: In case of errors, please make sure that the `artifactId` in the `pom.xml` file reads `javacv-platform`, not `javacv` only, for example. The artifact `javacv-platform` adds all the necessary binary dependencies.
 
 Build Instructions
 ------------------


### PR DESCRIPTION
It happened to me I searched for latest javacv in maven artifactory. Since artefact javacv exists I copy pasted it into my pom.xml instead of including javacv-platform. I assume this issue can be experienced by more people, thus added a warning in the README.md about being careful the dependency is really what it should be.