### PR TITLE
(FFmpeg)FrameGrabber: create and use maxDelay

### DIFF
--- a/src/main/java/org/bytedeco/javacv/FFmpegFrameGrabber.java
+++ b/src/main/java/org/bytedeco/javacv/FFmpegFrameGrabber.java
@@ -572,6 +572,8 @@ public class FFmpegFrameGrabber extends FrameGrabber {
         }
         av_dict_free(options);
 
+        oc.max_delay(maxDelay);
+
         // Retrieve stream information
         if ((ret = avformat_find_stream_info(oc, (PointerPointer)null)) < 0) {
             throw new Exception("avformat_find_stream_info() error " + ret + ": Could not find stream information.");

--- a/src/main/java/org/bytedeco/javacv/FrameGrabber.java
+++ b/src/main/java/org/bytedeco/javacv/FrameGrabber.java
@@ -200,6 +200,7 @@ public abstract class FrameGrabber implements Closeable {
     protected Map<String, String> audioMetadata = new HashMap<String, String>();
     protected int frameNumber = 0;
     protected long timestamp = 0;
+    protected int maxDelay = -1;
 
     public int getVideoStream() {
         return videoStream;
@@ -465,6 +466,13 @@ public abstract class FrameGrabber implements Closeable {
     }
     public void setTimestamp(long timestamp) throws Exception {
         this.timestamp = timestamp;
+    }
+
+    public int getMaxDelay() {
+        return maxDelay;
+    }
+    public void setMaxDelay(int maxDelay) {
+        this.maxDelay = maxDelay;
     }
 
     public int getLengthInFrames() {


### PR DESCRIPTION
Used to set the maxDelay the AVFormat is allowed to cause.