### PR TITLE
Add JavaFXConverter

### DIFF
--- a/src/main/java/org/bytedeco/javacv/JavaFXFrameConverter.java
+++ b/src/main/java/org/bytedeco/javacv/JavaFXFrameConverter.java
@@ -62,24 +62,26 @@ public class JavaFXFrameConverter extends FrameConverter<Image> {
 
         @Override
         public PixelFormat getPixelFormat() {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("getPixelFormat not supported yet.");
         }
 
         @Override
         public int getArgb(int x, int y) {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("getArgb not supported yet.");
         }
 
         @Override
         public Color getColor(int x, int y) {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("getColor not supported yet.");
         }
 
         @Override
         public <T extends Buffer> void getPixels(int x, int y, int w, int h, WritablePixelFormat<T> pixelformat, T buffer, int scanlineStride) {
             int fss = frame.imageStride;
+            if (frame.imageChannels != 3) {
+                throw new UnsupportedOperationException("We only support frames with imageChannels = 3 (BGR)");
+            }
             if (buffer instanceof ByteBuffer) {
-
                 ByteBuffer bb = (ByteBuffer) buffer;
                 int tot = 0;
                 ByteBuffer b = (ByteBuffer) frame.image[0];
@@ -99,12 +101,12 @@ public class JavaFXFrameConverter extends FrameConverter<Image> {
 
         @Override
         public void getPixels(int x, int y, int w, int h, WritablePixelFormat<ByteBuffer> pixelformat, byte[] buffer, int offset, int scanlineStride) {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("getPixels<ByteBuffer> Not supported yet.");
         }
 
         @Override
         public void getPixels(int x, int y, int w, int h, WritablePixelFormat<IntBuffer> pixelformat, int[] buffer, int offset, int scanlineStride) {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("getPixels<IntBuffer>Not supported yet.");
         }
 
     }

--- a/src/main/java/org/bytedeco/javacv/JavaFXFrameConverter.java
+++ b/src/main/java/org/bytedeco/javacv/JavaFXFrameConverter.java
@@ -83,7 +83,6 @@ public class JavaFXFrameConverter extends FrameConverter<Image> {
             }
             if (buffer instanceof ByteBuffer) {
                 ByteBuffer bb = (ByteBuffer) buffer;
-                int tot = 0;
                 ByteBuffer b = (ByteBuffer) frame.image[0];
                 for (int i = y; i < y + h; i++) {
                     for (int j = x; j < x + w; j++) {
@@ -92,7 +91,6 @@ public class JavaFXFrameConverter extends FrameConverter<Image> {
                         bb.put(b.get(fss * i + base + 1));
                         bb.put(b.get(fss * i + base + 2));
                         bb.put((byte) 255);
-                        tot = tot + 4;
                     }
                 }
 

--- a/src/main/java/org/bytedeco/javacv/JavaFXFrameConverter.java
+++ b/src/main/java/org/bytedeco/javacv/JavaFXFrameConverter.java
@@ -1,3 +1,24 @@
+/*
+ * Copyright (C) 2018 Samuel Audet, Johan Vos
+ *
+ * Licensed either under the Apache License, Version 2.0, or (at your option)
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation (subject to the "Classpath" exception),
+ * either version 2, or any later version (collectively, the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.gnu.org/licenses/
+ *     http://www.gnu.org/software/classpath/license.html
+ *
+ * or as provided in the LICENSE.txt file that accompanied this code.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.bytedeco.javacv;
 
 import java.nio.Buffer;
@@ -6,13 +27,13 @@ import java.nio.IntBuffer;
 import javafx.scene.image.Image;
 import javafx.scene.image.PixelFormat;
 import javafx.scene.image.PixelReader;
-import javafx.scene.image.PixelWriter;
 import javafx.scene.image.WritableImage;
 import javafx.scene.image.WritablePixelFormat;
 import javafx.scene.paint.Color;
 
 /**
  *
+ * Convert Frames into JavaFX images and vice versa
  * @author johan
  */
 public class JavaFXFrameConverter extends FrameConverter<Image> {
@@ -73,7 +94,7 @@ public class JavaFXFrameConverter extends FrameConverter<Image> {
                     }
                 }
 
-            }
+            } else throw new UnsupportedOperationException ("We only support bytebuffers at the moment");
         }
 
         @Override

--- a/src/main/java/org/bytedeco/javacv/JavaFXFrameConverter.java
+++ b/src/main/java/org/bytedeco/javacv/JavaFXFrameConverter.java
@@ -6,6 +6,7 @@ import java.nio.IntBuffer;
 import javafx.scene.image.Image;
 import javafx.scene.image.PixelFormat;
 import javafx.scene.image.PixelReader;
+import javafx.scene.image.PixelWriter;
 import javafx.scene.image.WritableImage;
 import javafx.scene.image.WritablePixelFormat;
 import javafx.scene.paint.Color;
@@ -14,7 +15,7 @@ import javafx.scene.paint.Color;
  *
  * @author johan
  */
-public class JavaFXFrameConverter extends FrameConverter<Image>{
+public class JavaFXFrameConverter extends FrameConverter<Image> {
 
     @Override
     public Frame convert(Image f) {
@@ -29,15 +30,15 @@ public class JavaFXFrameConverter extends FrameConverter<Image>{
         WritableImage answer = new WritableImage(pr, iw, ih);
         return answer;
     }
-    
+
     class FramePixelReader implements PixelReader {
 
         Frame frame;
-        
+
         FramePixelReader(Frame f) {
             this.frame = f;
         }
-        
+
         @Override
         public PixelFormat getPixelFormat() {
             throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
@@ -55,7 +56,24 @@ public class JavaFXFrameConverter extends FrameConverter<Image>{
 
         @Override
         public <T extends Buffer> void getPixels(int x, int y, int w, int h, WritablePixelFormat<T> pixelformat, T buffer, int scanlineStride) {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            int fss = frame.imageStride;
+            if (buffer instanceof ByteBuffer) {
+
+                ByteBuffer bb = (ByteBuffer) buffer;
+                int tot = 0;
+                ByteBuffer b = (ByteBuffer) frame.image[0];
+                for (int i = y; i < y + h; i++) {
+                    for (int j = x; j < x + w; j++) {
+                        int base = 3 * j;
+                        bb.put(b.get(fss * i + base));
+                        bb.put(b.get(fss * i + base + 1));
+                        bb.put(b.get(fss * i + base + 2));
+                        bb.put((byte) 255);
+                        tot = tot + 4;
+                    }
+                }
+
+            }
         }
 
         @Override
@@ -67,7 +85,7 @@ public class JavaFXFrameConverter extends FrameConverter<Image>{
         public void getPixels(int x, int y, int w, int h, WritablePixelFormat<IntBuffer> pixelformat, int[] buffer, int offset, int scanlineStride) {
             throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
         }
-        
+
     }
-    
+
 }

--- a/src/main/java/org/bytedeco/javacv/JavaFXFrameConverter.java
+++ b/src/main/java/org/bytedeco/javacv/JavaFXFrameConverter.java
@@ -1,0 +1,73 @@
+package org.bytedeco.javacv;
+
+import java.nio.Buffer;
+import java.nio.ByteBuffer;
+import java.nio.IntBuffer;
+import javafx.scene.image.Image;
+import javafx.scene.image.PixelFormat;
+import javafx.scene.image.PixelReader;
+import javafx.scene.image.WritableImage;
+import javafx.scene.image.WritablePixelFormat;
+import javafx.scene.paint.Color;
+
+/**
+ *
+ * @author johan
+ */
+public class JavaFXFrameConverter extends FrameConverter<Image>{
+
+    @Override
+    public Frame convert(Image f) {
+        return null;
+    }
+
+    @Override
+    public Image convert(Frame frame) {
+        int iw = frame.imageWidth;
+        int ih = frame.imageHeight;
+        PixelReader pr = new FramePixelReader(frame);
+        WritableImage answer = new WritableImage(pr, iw, ih);
+        return answer;
+    }
+    
+    class FramePixelReader implements PixelReader {
+
+        Frame frame;
+        
+        FramePixelReader(Frame f) {
+            this.frame = f;
+        }
+        
+        @Override
+        public PixelFormat getPixelFormat() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public int getArgb(int x, int y) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public Color getColor(int x, int y) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public <T extends Buffer> void getPixels(int x, int y, int w, int h, WritablePixelFormat<T> pixelformat, T buffer, int scanlineStride) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public void getPixels(int x, int y, int w, int h, WritablePixelFormat<ByteBuffer> pixelformat, byte[] buffer, int offset, int scanlineStride) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public void getPixels(int x, int y, int w, int h, WritablePixelFormat<IntBuffer> pixelformat, int[] buffer, int offset, int scanlineStride) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+        
+    }
+    
+}


### PR DESCRIPTION
This class converts a Frame into a JavaFX Image, leveraging the ByteBuffer that is underlying both Frame and Image.
Only BGR Frames are supported at this moment. In case a non-supported format is used, appropriate exceptions are thrown.
We can easily add more formats, but it is easier to do this with real test scenarios once we run into them.