### PR TITLE
Update README.md (pom example) due to compile error with Java source level 1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,8 +268,8 @@ Furthermore, after creating a `pom.xml` file with the following content:
     <artifactId>demo</artifactId>
     <version>1.4.2</version>
     <properties>
-        <maven.compiler.source>1.6</maven.compiler.source>
-        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
     </properties>
     <dependencies>
         <dependency>

--- a/README.md
+++ b/README.md
@@ -267,6 +267,10 @@ Furthermore, after creating a `pom.xml` file with the following content:
     <groupId>org.bytedeco.javacv</groupId>
     <artifactId>demo</artifactId>
     <version>1.4.2</version>
+    <properties>
+        <maven.compiler.source>1.6</maven.compiler.source>
+        <maven.compiler.target>1.6</maven.compiler.target>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>org.bytedeco</groupId>


### PR DESCRIPTION
Depending on the version of the maven-compiler plugin the default level was 1.5 prior to plugin version 3.8.0 (https://maven.apache.org/plugins/maven-compiler-plugin/compile-mojo.html#source)

Using the source level 1.5 leads to a compile error, when using the pom example to execute the Demo code.

added maven compiler properties to set version of Java source and target explicitelly to 1.6.

