### PR TITLE
IPCameraFrameGrabber converter OpenCVFrameConverter<IplImage> -> Open…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 
+ * Fix `OpenCVFrameConverter` error in `IPCameraFrameGrabber` ([pull #1278](https://github.com/bytedeco/javacv/pull/1278))
  * Allow setting properties for `OpenCVFrameGrabber` and `OpenCVFrameRecorder` with `setOption()` ([issue #1269](https://github.com/bytedeco/javacv/issues/1269))
  * Add missing `requires java.desktop` to `module-info.java` ([issue #1265](https://github.com/bytedeco/javacv/issues/1265))
  * Upgrade dependencies for OpenCV 4.1.1, FFmpeg 4.2

--- a/src/main/java/org/bytedeco/javacv/IPCameraFrameGrabber.java
+++ b/src/main/java/org/bytedeco/javacv/IPCameraFrameGrabber.java
@@ -63,7 +63,7 @@ public class IPCameraFrameGrabber extends FrameGrabber {
         }
     }
 
-    private final FrameConverter converter = new OpenCVFrameConverter.ToIplImage();
+    private final FrameConverter converter = new OpenCVFrameConverter.ToMat();
     private final URL url;
     private final int connectionTimeout;
     private final int readTimeout;


### PR DESCRIPTION
Fixed error
```
java.lang.ClassCastException: org.bytedeco.opencv.opencv_core.Mat cannot be cast to org.bytedeco.opencv.opencv_core.IplImage
	at org.bytedeco.javacv.OpenCVFrameConverter$ToIplImage.convert(OpenCVFrameConverter.java:49)
	at org.bytedeco.javacv.IPCameraFrameGrabber.grab(IPCameraFrameGrabber.java:166)
```