### PR TITLE
Implemented realsense2 FrameGrabber for depth, ir and color streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 
+ * Add `RealSense2FrameGrabber` to capture images with librealsense2 ([pull #1316](https://github.com/bytedeco/javacv/pull/1316))
  * Disable seek function in `FFmpegFrameGrabber` when `maximumSize <= 0` ([issue #1304](https://github.com/bytedeco/javacv/issues/1304))
  * Use `Pointer.retainReference()` to prevent `PointerScope` from deallocating globally shared callback objects for FFmpeg
  * Fix `FFmpegFrameRecorder` failing to encode `float` samples in MP3 ([issue #1294](https://github.com/bytedeco/javacv/issues/1294))
  * Fix `OpenCVFrameConverter` error in `IPCameraFrameGrabber` ([pull #1278](https://github.com/bytedeco/javacv/pull/1278))
  * Allow setting properties for `OpenCVFrameGrabber` and `OpenCVFrameRecorder` with `setOption()` ([issue #1269](https://github.com/bytedeco/javacv/issues/1269))
  * Add missing `requires java.desktop` to `module-info.java` ([issue #1265](https://github.com/bytedeco/javacv/issues/1265))
- * Upgrade dependencies for OpenBLAS 0.3.7, OpenCV 4.1.1, FFmpeg 4.2.1, librealsense 1.12.4 and 2.25.0
+ * Upgrade dependencies for OpenBLAS 0.3.7, OpenCV 4.1.1, FFmpeg 4.2.1, librealsense 1.12.4, and librealsense2 2.25.0
 
 ### July 9, 2019 version 1.5.1
  * Work around `swscale` bug in `FFmpegFrameGrabber` for images with unaligned width ([issue #845](https://github.com/bytedeco/javacv/issues/845))

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ public class Demo {
 
         // The available FrameGrabber classes include OpenCVFrameGrabber (opencv_videoio),
         // DC1394FrameGrabber, FlyCapture2FrameGrabber, OpenKinectFrameGrabber, OpenKinect2FrameGrabber,
-        // RealSenseFrameGrabber, PS3EyeFrameGrabber, VideoInputFrameGrabber, and FFmpegFrameGrabber.
+        // RealSenseFrameGrabber, RealSense2FrameGrabber, PS3EyeFrameGrabber, VideoInputFrameGrabber, and FFmpegFrameGrabber.
         FrameGrabber grabber = FrameGrabber.createDefault(0);
         grabber.start();
 

--- a/samples/Demo.java
+++ b/samples/Demo.java
@@ -54,7 +54,7 @@ public class Demo {
 
         // The available FrameGrabber classes include OpenCVFrameGrabber (opencv_videoio),
         // DC1394FrameGrabber, FlyCapture2FrameGrabber, OpenKinectFrameGrabber, OpenKinect2FrameGrabber,
-        // RealSenseFrameGrabber, PS3EyeFrameGrabber, VideoInputFrameGrabber, and FFmpegFrameGrabber.
+        // RealSenseFrameGrabber, RealSense2FrameGrabber, PS3EyeFrameGrabber, VideoInputFrameGrabber, and FFmpegFrameGrabber.
         FrameGrabber grabber = FrameGrabber.createDefault(0);
         grabber.start();
 

--- a/samples/RealSense2DepthMeasuring.java
+++ b/samples/RealSense2DepthMeasuring.java
@@ -33,7 +33,7 @@ public class RealSense2DepthMeasuring {
         RealSense2FrameGrabber rs2 = new RealSense2FrameGrabber();
 
         // list all cameras
-        for(RealSense2FrameGrabber.RealSense2DeviceInfo info : rs2.getDeviceInfos()) {
+        for (RealSense2FrameGrabber.RealSense2DeviceInfo info : rs2.getDeviceInfos()) {
             System.out.printf("Device: %s %s %s Locked: %b\n",
                     info.getName(),
                     info.getFirmware(),
@@ -46,9 +46,9 @@ public class RealSense2DepthMeasuring {
 
         // here are more examples of streams:
         /*
-        rs2.addColorStream(640, 480, 30); // color stream
-        rs2.addIRStream(640, 480, 90); // ir stream
-        rs2.addStream(new RealSense2FrameGrabber.RealSenseStream(
+        rs2.enableColorStream(640, 480, 30); // color stream
+        rs2.enableIRStream(640, 480, 90); // ir stream
+        rs2.enableStream(new RealSense2FrameGrabber.RealSenseStream(
                 RS2_STREAM_INFRARED,
                 2,
                 new Size(640, 480),

--- a/samples/RealSense2DepthMeasuring.java
+++ b/samples/RealSense2DepthMeasuring.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2019 Florian Bruggisser
+ *
+ * Licensed either under the Apache License, Version 2.0, or (at your option)
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation (subject to the "Classpath" exception),
+ * either version 2, or any later version (collectively, the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.gnu.org/licenses/
+ *     http://www.gnu.org/software/classpath/license.html
+ *
+ * or as provided in the LICENSE.txt file that accompanied this code.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.bytedeco.javacv.CanvasFrame;
+import org.bytedeco.javacv.Frame;
+import org.bytedeco.javacv.FrameGrabber;
+import org.bytedeco.javacv.RealSense2FrameGrabber;
+
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+
+public class RealSense2DepthMeasuring {
+    public static void main(String[] args) throws FrameGrabber.Exception {
+        RealSense2FrameGrabber rs2 = new RealSense2FrameGrabber();
+
+        // list all cameras
+        for(RealSense2FrameGrabber.RealSense2DeviceInfo info : rs2.getDeviceInfos()) {
+            System.out.printf("Device: %s %s %s Locked: %b\n",
+                    info.getName(),
+                    info.getFirmware(),
+                    info.getSerialNumber(),
+                    info.isLocked());
+        }
+
+        // enable the depth stream of the realsense camera
+        rs2.addDepthStream(640, 480, 30);
+
+        // here are more examples of streams:
+        /*
+        rs2.addColorStream(640, 480, 30); // color stream
+        rs2.addIRStream(640, 480, 90); // ir stream
+        rs2.addStream(new RealSense2FrameGrabber.RealSenseStream(
+                RS2_STREAM_INFRARED,
+                2,
+                new Size(640, 480),
+                30,
+                RS2_FORMAT_Y8
+        )); // second ir stream
+        */
+
+        // start realsense camera
+        rs2.start();
+
+        // start frame to view the stream
+        CanvasFrame canvasFrame = new CanvasFrame("RealSense");
+        canvasFrame.setCanvasSize(rs2.getImageWidth(), rs2.getImageHeight());
+
+        // add mouse listener to see the depth at the clicked point
+        canvasFrame.getCanvas().addMouseListener(new MouseAdapter() {
+            @Override
+            public void mousePressed(MouseEvent e) {
+                try {
+                    System.out.println("Depth: " + rs2.getDistance(e.getX(), e.getY()));
+                } catch (FrameGrabber.Exception ex) {
+                    ex.printStackTrace();
+                }
+            }
+        });
+
+        // run canvas
+        while (canvasFrame.isVisible()) {
+            // trigger camera to capture images
+            rs2.trigger();
+
+            // display images -> grab will return the first stream added
+            // use rs2.grabDepth(), rs2.grabColor() and rs2.grabIR() for the other streams
+            Frame frame = rs2.grab();
+
+            // display frame
+            canvasFrame.showImage(frame);
+        }
+
+        // close realsense camera
+        rs2.stop();
+        rs2.release();
+        canvasFrame.dispose();
+
+    }
+}

--- a/samples/RealSense2DepthMeasuring.java
+++ b/samples/RealSense2DepthMeasuring.java
@@ -42,7 +42,7 @@ public class RealSense2DepthMeasuring {
         }
 
         // enable the depth stream of the realsense camera
-        rs2.addDepthStream(640, 480, 30);
+        rs2.enableDepthStream(640, 480, 30);
 
         // here are more examples of streams:
         /*

--- a/src/main/java/org/bytedeco/javacv/FrameGrabber.java
+++ b/src/main/java/org/bytedeco/javacv/FrameGrabber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2018 Samuel Audet
+ * Copyright (C) 2009-2019 Samuel Audet
  *
  * Licensed either under the Apache License, Version 2.0, or (at your option)
  * under the terms of the GNU General Public License as published by
@@ -45,7 +45,7 @@ import java.util.concurrent.Future;
 public abstract class FrameGrabber implements Closeable {
 
     public static final List<String> list = new LinkedList<String>(Arrays.asList(new String[] {
-		"DC1394", "FlyCapture", "FlyCapture2", "OpenKinect", "OpenKinect2", "RealSense", "PS3Eye", "VideoInput", "OpenCV", "FFmpeg", "IPCamera" }));
+		"DC1394", "FlyCapture", "FlyCapture2", "OpenKinect", "OpenKinect2", "RealSense", "RealSense2", "PS3Eye", "VideoInput", "OpenCV", "FFmpeg", "IPCamera" }));
     public static void init() {
         for (String name : list) {
             try {

--- a/src/main/java/org/bytedeco/javacv/RealSense2FrameGrabber.java
+++ b/src/main/java/org/bytedeco/javacv/RealSense2FrameGrabber.java
@@ -1,0 +1,278 @@
+/*
+ * Copyright (C) 2019 Florian Bruggisser
+ *
+ * Licensed either under the Apache License, Version 2.0, or (at your option)
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation (subject to the "Classpath" exception),
+ * either version 2, or any later version (collectively, the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.gnu.org/licenses/
+ *     http://www.gnu.org/software/classpath/license.html
+ *
+ * or as provided in the LICENSE.txt file that accompanied this code.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bytedeco.javacv;
+
+import org.bytedeco.javacpp.Pointer;
+import org.bytedeco.librealsense2.*;
+import org.bytedeco.opencv.opencv_core.IplImage;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.bytedeco.librealsense2.global.realsense2.*;
+import static org.bytedeco.opencv.global.opencv_core.*;
+
+public class RealSense2FrameGrabber extends FrameGrabber {
+    private rs2_error error = new rs2_error();
+    private rs2_context context;
+    private rs2_device device;
+    private rs2_pipeline pipeline;
+    private rs2_config config;
+    private rs2_pipeline_profile pipelineProfile;
+
+    private int deviceNumber;
+
+    private FrameConverter converter = new OpenCVFrameConverter.ToIplImage();
+
+    public RealSense2FrameGrabber() throws Exception {
+        this(0);
+    }
+
+    public RealSense2FrameGrabber(int deviceNumber) throws FrameGrabber.Exception {
+        this.deviceNumber = deviceNumber;
+
+        // create context
+        this.context = createContext();
+    }
+
+    public List<RealSense2DeviceInfo> getDeviceInfos() throws Exception {
+        List<RealSense2DeviceInfo> devices = new ArrayList<>();
+
+        rs2_device_list deviceList = createDeviceList();
+        int count = rs2_get_device_count(deviceList, error);
+        checkError(error);
+
+        for (int i = 0; i < count; i++) {
+            rs2_device device = createDevice(deviceList, i);
+            devices.add(new RealSense2DeviceInfo(
+                    getDeviceInfo(device, RS2_CAMERA_INFO_NAME),
+                    getDeviceInfo(device, RS2_CAMERA_INFO_SERIAL_NUMBER),
+                    getDeviceInfo(device, RS2_CAMERA_INFO_FIRMWARE_VERSION),
+                    toBoolean(getDeviceInfo(device, RS2_CAMERA_INFO_ADVANCED_MODE)),
+                    toBoolean(getDeviceInfo(device, RS2_CAMERA_INFO_CAMERA_LOCKED))
+            ));
+            rs2_delete_device(device);
+        }
+
+        rs2_delete_device_list(deviceList);
+        return devices;
+    }
+
+    @Override
+    public void start() throws FrameGrabber.Exception {
+        // check if device is available
+        if (getDeviceCount() <= 0) {
+            throw new FrameGrabber.Exception("No rs2_device is connected!");
+        }
+
+        // create device
+        rs2_device_list devices = createDeviceList();
+        this.device = createDevice(devices, this.deviceNumber);
+
+        // create pipeline
+        this.pipeline = createPipeline();
+        this.config = createConfig();
+
+        // enable streams
+        // todo: implement enable all available streams
+        rs2_config_enable_stream(config, RS2_STREAM_DEPTH, 0, 640, 0, RS2_FORMAT_Z16, 30, error);
+        checkError(error);
+
+        // start pipeline
+        pipelineProfile = rs2_pipeline_start_with_config(pipeline, config, error);
+        checkError(error);
+    }
+
+    @Override
+    public void stop() throws Exception {
+        rs2_pipeline_stop(this.pipeline, error);
+        checkError(error);
+
+        rs2_delete_pipeline_profile(this.pipelineProfile);
+        rs2_delete_config(this.config);
+        rs2_delete_pipeline(this.pipeline);
+        rs2_delete_device(this.device);
+        this.device = null;
+    }
+
+    @Override
+    public void trigger() throws Exception {
+        rs2_frame frames = rs2_pipeline_wait_for_frames(pipeline, RS2_DEFAULT_TIMEOUT, error);
+        checkError(error);
+        rs2_release_frame(frames);
+    }
+
+    @Override
+    public Frame grab() throws Exception {
+        Frame cvFrame = null;
+        rs2_frame frames = rs2_pipeline_wait_for_frames(pipeline, RS2_DEFAULT_TIMEOUT, error);
+        checkError(error);
+
+        int frameCount = rs2_embedded_frames_count(frames, error);
+        checkError(error);
+
+        for (int i = 0; i < frameCount; i++) {
+            rs2_frame frame = rs2_extract_frame(frames, i, error);
+            checkError(error);
+
+            // get frame dimensions
+            int width = rs2_get_frame_width(frame, error);
+            checkError(error);
+            int height = rs2_get_frame_height(frame, error);
+            checkError(error);
+
+            // todo: read all different frame types
+            if (0 == rs2_is_frame_extendable_to(frame, RS2_EXTENSION_DEPTH_FRAME, error))
+                continue;
+
+            Pointer frameData = rs2_get_frame_data(frame, error);
+            checkError(error);
+
+            IplImage image = IplImage.createHeader(width, height, IPL_DEPTH_16U, 1);
+            // todo: check if this really is correct
+            cvSetData(image, frameData, width * IPL_DEPTH_16U / 8);
+            cvFrame = converter.convert(image);
+
+            rs2_release_frame(frame);
+        }
+
+        rs2_release_frame(frames);
+        return cvFrame;
+    }
+
+    @Override
+    public void release() throws Exception {
+        rs2_delete_device(this.device);
+        rs2_delete_context(this.context);
+    }
+
+    private rs2_context createContext() throws FrameGrabber.Exception {
+        rs2_context context = rs2_create_context(RS2_API_VERSION, error);
+        checkError(error);
+        return context;
+    }
+
+    private rs2_device_list createDeviceList() throws FrameGrabber.Exception {
+        rs2_device_list deviceList = rs2_query_devices(context, error);
+        checkError(error);
+        return deviceList;
+    }
+
+    private rs2_device createDevice(rs2_device_list deviceList, int index) throws FrameGrabber.Exception {
+        rs2_device device = rs2_create_device(deviceList, index, error);
+        checkError(error);
+        return device;
+    }
+
+    private rs2_pipeline createPipeline() throws FrameGrabber.Exception {
+        rs2_pipeline pipeline = rs2_create_pipeline(context, error);
+        checkError(error);
+        return pipeline;
+    }
+
+    private rs2_config createConfig() throws FrameGrabber.Exception {
+        rs2_config config = rs2_create_config(error);
+        checkError(error);
+        return config;
+    }
+
+    private int getDeviceCount() throws FrameGrabber.Exception {
+        rs2_device_list deviceList = createDeviceList();
+        int count = rs2_get_device_count(deviceList, error);
+
+        checkError(error);
+        rs2_delete_device_list(deviceList);
+        return count;
+    }
+
+    private String getDeviceInfo(rs2_device device, int info) throws FrameGrabber.Exception {
+        // check if info is supported
+        rs2_error error = new rs2_error();
+        boolean isSupported = toBoolean(rs2_supports_device_info(device, info, error));
+        checkError(error);
+
+        if (!isSupported)
+            return null;
+
+        // read device info
+        String infoText = rs2_get_device_info(device, info, error).getString();
+        checkError(error);
+
+        return infoText;
+    }
+
+    private static void checkError(rs2_error e) throws FrameGrabber.Exception {
+        if (!e.isNull()) {
+            throw new FrameGrabber.Exception(String.format("rs_error was raised when calling %s(%s):\n%s\n",
+                    rs2_get_failed_function(e),
+                    rs2_get_failed_args(e),
+                    rs2_get_error_message(e)));
+        }
+    }
+
+    private static boolean toBoolean(int value) {
+        return value >= 1;
+    }
+
+    private static boolean toBoolean(String value) {
+        if (value == null)
+            return false;
+
+        return value.equals("YES");
+    }
+
+    public class RealSense2DeviceInfo {
+        private String name;
+        private String serialNumber;
+        private String firmware;
+        private boolean inAdvancedMode;
+        private boolean locked;
+
+        public RealSense2DeviceInfo(String name, String serialNumber, String firmware, boolean inAdvancedMode, boolean locked) {
+            this.name = name;
+            this.serialNumber = serialNumber;
+            this.firmware = firmware;
+            this.inAdvancedMode = inAdvancedMode;
+            this.locked = locked;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getSerialNumber() {
+            return serialNumber;
+        }
+
+        public String getFirmware() {
+            return firmware;
+        }
+
+        public boolean isInAdvancedMode() {
+            return inAdvancedMode;
+        }
+
+        public boolean isLocked() {
+            return locked;
+        }
+    }
+}

--- a/src/main/java/org/bytedeco/javacv/RealSense2FrameGrabber.java
+++ b/src/main/java/org/bytedeco/javacv/RealSense2FrameGrabber.java
@@ -45,7 +45,7 @@ public class RealSense2FrameGrabber extends FrameGrabber {
     private rs2_frame frameset;
 
     private int deviceNumber;
-    private ArrayList<RealSenseStream> streams = new ArrayList<>();
+    private List<RealSenseStream> streams = new ArrayList<>();
 
     private FrameConverter converter = new OpenCVFrameConverter.ToIplImage();
 
@@ -81,6 +81,20 @@ public class RealSense2FrameGrabber extends FrameGrabber {
 
         rs2_delete_device_list(deviceList);
         return devices;
+    }
+
+    public static String[] getDeviceDescriptions() throws FrameGrabber.Exception {
+        RealSense2FrameGrabber rs2 = new RealSense2FrameGrabber();
+        List<RealSense2DeviceInfo> infos = rs2.getDeviceInfos();
+        rs2.release();
+
+        String[] deviceDescriptions = new String[infos.size()];
+        for(int i = 0; i < deviceDescriptions.length; i++) {
+            RealSense2DeviceInfo info = infos.get(i);
+            deviceDescriptions[i] = info.toString();
+        }
+
+        return deviceDescriptions;
     }
 
     public void disableAllStreams() {
@@ -499,6 +513,11 @@ public class RealSense2FrameGrabber extends FrameGrabber {
 
         public boolean isLocked() {
             return locked;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("%s", name);
         }
     }
 }

--- a/src/main/java/org/bytedeco/javacv/RealSense2FrameGrabber.java
+++ b/src/main/java/org/bytedeco/javacv/RealSense2FrameGrabber.java
@@ -149,6 +149,7 @@ public class RealSense2FrameGrabber extends FrameGrabber {
         // create device
         rs2_device_list devices = createDeviceList();
         this.device = createDevice(devices, this.deviceNumber);
+        rs2_delete_device_list(devices);
 
         // create pipeline
         this.pipeline = createPipeline();

--- a/src/main/java/org/bytedeco/javacv/RealSense2FrameGrabber.java
+++ b/src/main/java/org/bytedeco/javacv/RealSense2FrameGrabber.java
@@ -405,9 +405,9 @@ public class RealSense2FrameGrabber extends FrameGrabber {
     private static void checkError(rs2_error e) throws FrameGrabber.Exception {
         if (!e.isNull()) {
             throw new FrameGrabber.Exception(String.format("rs_error was raised when calling %s(%s):\n%s\n",
-                    rs2_get_failed_function(e),
-                    rs2_get_failed_args(e),
-                    rs2_get_error_message(e)));
+                    rs2_get_failed_function(e).getString(),
+                    rs2_get_failed_args(e).getString(),
+                    rs2_get_error_message(e).getString()));
         }
     }
 

--- a/src/main/java/org/bytedeco/javacv/RealSense2FrameGrabber.java
+++ b/src/main/java/org/bytedeco/javacv/RealSense2FrameGrabber.java
@@ -175,8 +175,6 @@ public class RealSense2FrameGrabber extends FrameGrabber {
         int frameCount = rs2_embedded_frames_count(frameset, error);
         checkError(error);
 
-        System.out.println("found n streams:" + frameCount);
-
         int i = 0;
         int searchIndex = 0;
         while (i < frameCount) {
@@ -324,12 +322,12 @@ public class RealSense2FrameGrabber extends FrameGrabber {
         return value.equals("YES");
     }
 
-    private static class StreamProfileData {
-        IntPointer nativeStreamIndex = new IntPointer();
-        IntPointer nativeFormatIndex = new IntPointer();
-        IntPointer index = new IntPointer();
-        IntPointer uniqueId = new IntPointer();
-        IntPointer frameRate = new IntPointer();
+    static class StreamProfileData {
+        IntPointer nativeStreamIndex = new IntPointer(1);
+        IntPointer nativeFormatIndex = new IntPointer(1);
+        IntPointer index = new IntPointer(1);
+        IntPointer uniqueId = new IntPointer(1);
+        IntPointer frameRate = new IntPointer(1);
     }
 
     public static class RealSense2DeviceInfo {

--- a/src/main/java/org/bytedeco/javacv/RealSense2FrameGrabber.java
+++ b/src/main/java/org/bytedeco/javacv/RealSense2FrameGrabber.java
@@ -196,7 +196,18 @@ public class RealSense2FrameGrabber extends FrameGrabber {
 
     @Override
     public Frame grab() throws FrameGrabber.Exception {
-        return grabColor();
+        RealSenseStream stream = streams.get(0);
+
+        switch (stream.type) {
+            case RS2_STREAM_DEPTH:
+                return grabDepth();
+
+            case RS2_STREAM_INFRARED:
+                return grabIR();
+
+            default:
+                return grabColor();
+        }
     }
 
     public float getDistance(int x, int y) throws Exception {

--- a/src/main/java/org/bytedeco/javacv/RealSense2FrameGrabber.java
+++ b/src/main/java/org/bytedeco/javacv/RealSense2FrameGrabber.java
@@ -103,7 +103,7 @@ public class RealSense2FrameGrabber extends FrameGrabber {
                 0,
                 new Size(width, height),
                 frameRate,
-                RS2_FORMAT_RGB8
+                RS2_FORMAT_BGR8
         ));
     }
 

--- a/src/main/java/org/bytedeco/javacv/RealSense2FrameGrabber.java
+++ b/src/main/java/org/bytedeco/javacv/RealSense2FrameGrabber.java
@@ -139,7 +139,8 @@ public class RealSense2FrameGrabber extends FrameGrabber {
 
     @Override
     public Frame grab() throws FrameGrabber.Exception {
-        return grabDepthOld();
+        // todo: implement this
+        return new Frame();
     }
 
     public Frame grabDepth() throws Exception {
@@ -163,38 +164,6 @@ public class RealSense2FrameGrabber extends FrameGrabber {
 
         // cleanup
         rs2_release_frame(frame);
-
-        return depthFrame;
-    }
-
-    public Frame grabDepthOld() throws FrameGrabber.Exception {
-        Frame depthFrame = null;
-
-        int frameCount = rs2_embedded_frames_count(frameset, error);
-        checkError(error);
-
-        for (int i = 0; i < frameCount; i++) {
-            rs2_frame frame = rs2_extract_frame(frameset, i, error);
-            checkError(error);
-
-            if (toBoolean(rs2_is_frame_extendable_to(frame, RS2_EXTENSION_DEPTH_FRAME, error))) {
-                Pointer frameData = rs2_get_frame_data(frame, error);
-                checkError(error);
-
-                // get frame dimensions
-                int width = rs2_get_frame_width(frame, error);
-                checkError(error);
-                int height = rs2_get_frame_height(frame, error);
-                checkError(error);
-
-                IplImage image = IplImage.createHeader(width, height, IPL_DEPTH_16U, 1);
-                // todo: check if this really is correct
-                cvSetData(image, frameData, width * IPL_DEPTH_16U / 8);
-                depthFrame = converter.convert(image);
-            }
-
-            rs2_release_frame(frame);
-        }
 
         return depthFrame;
     }

--- a/src/main/java/org/bytedeco/javacv/RealSense2FrameGrabber.java
+++ b/src/main/java/org/bytedeco/javacv/RealSense2FrameGrabber.java
@@ -103,7 +103,7 @@ public class RealSense2FrameGrabber extends FrameGrabber {
                 0,
                 new Size(width, height),
                 frameRate,
-                RS2_FORMAT_BGR8
+                RS2_FORMAT_RGB8
         ));
     }
 
@@ -197,6 +197,17 @@ public class RealSense2FrameGrabber extends FrameGrabber {
     @Override
     public Frame grab() throws FrameGrabber.Exception {
         return grabColor();
+    }
+
+    public float getDistance(int x, int y) throws Exception {
+        rs2_frame frame = findFrameByStreamType(this.frameset, RS2_STREAM_DEPTH, 0);
+        if (frame == null)
+            return -1f;
+
+        float distance = rs2_depth_frame_get_distance(frame, x, y, error);
+        checkError(error);
+        rs2_release_frame(frame);
+        return distance;
     }
 
     public Frame grabColor() throws Exception {

--- a/src/main/java/org/bytedeco/javacv/RealSense2FrameGrabber.java
+++ b/src/main/java/org/bytedeco/javacv/RealSense2FrameGrabber.java
@@ -224,6 +224,7 @@ public class RealSense2FrameGrabber extends FrameGrabber {
                 break;
             }
 
+            rs2_delete_stream_profile(streamProfile);
             rs2_release_frame(frame);
             i++;
         }

--- a/src/main/java/org/bytedeco/javacv/RealSense2FrameGrabber.java
+++ b/src/main/java/org/bytedeco/javacv/RealSense2FrameGrabber.java
@@ -171,8 +171,6 @@ public class RealSense2FrameGrabber extends FrameGrabber {
             checkError(error);
         }
 
-        // todo: set options (emitter)
-
         // set image width & height to largest stream
         RealSenseStream largestStream = getLargestStreamByArea();
         this.imageWidth = largestStream.size.width();

--- a/src/main/java/org/bytedeco/javacv/RealSense2FrameGrabber.java
+++ b/src/main/java/org/bytedeco/javacv/RealSense2FrameGrabber.java
@@ -42,7 +42,6 @@ public class RealSense2FrameGrabber extends FrameGrabber {
     private rs2_pipeline_profile pipelineProfile;
 
     private rs2_frame frameset;
-    private boolean useTriggerToLoadFrames = false;
 
     private int deviceNumber;
     private List<RealSenseStream> streams = new ArrayList<>();
@@ -89,7 +88,7 @@ public class RealSense2FrameGrabber extends FrameGrabber {
         rs2.release();
 
         String[] deviceDescriptions = new String[infos.size()];
-        for(int i = 0; i < deviceDescriptions.length; i++) {
+        for (int i = 0; i < deviceDescriptions.length; i++) {
             RealSense2DeviceInfo info = infos.get(i);
             deviceDescriptions[i] = info.toString();
         }
@@ -209,8 +208,8 @@ public class RealSense2FrameGrabber extends FrameGrabber {
     @Override
     public void trigger() throws FrameGrabber.Exception {
         // set trigger load flag
-        if(!useTriggerToLoadFrames)
-            useTriggerToLoadFrames = true;
+        if (!triggerMode)
+            triggerMode = true;
 
         // read frames
         readNextFrameSet();
@@ -244,14 +243,14 @@ public class RealSense2FrameGrabber extends FrameGrabber {
     }
 
     public Frame grabColor() throws Exception {
-        if(!useTriggerToLoadFrames)
+        if (!triggerMode)
             readNextFrameSet();
 
         return grabCVFrame(RS2_STREAM_COLOR, 0, IPL_DEPTH_8U, 3);
     }
 
     public Frame grabDepth() throws Exception {
-        if(!useTriggerToLoadFrames)
+        if (!triggerMode)
             readNextFrameSet();
 
         return grabCVFrame(RS2_STREAM_DEPTH, 0, IPL_DEPTH_16U, 1);
@@ -262,7 +261,7 @@ public class RealSense2FrameGrabber extends FrameGrabber {
     }
 
     public Frame grabIR(int streamIndex) throws Exception {
-        if(!useTriggerToLoadFrames)
+        if (!triggerMode)
             readNextFrameSet();
 
         return grabCVFrame(RS2_STREAM_INFRARED, streamIndex, IPL_DEPTH_8U, 1);
@@ -270,8 +269,8 @@ public class RealSense2FrameGrabber extends FrameGrabber {
 
     private RealSenseStream getLargestStreamByArea() {
         RealSenseStream largest = streams.get(0);
-        for(RealSenseStream rs : streams) {
-            if(rs.size.area() > largest.size.area()) {
+        for (RealSenseStream rs : streams) {
+            if (rs.size.area() > largest.size.area()) {
                 largest = rs;
             }
         }

--- a/src/main/java/org/bytedeco/javacv/RealSense2FrameGrabber.java
+++ b/src/main/java/org/bytedeco/javacv/RealSense2FrameGrabber.java
@@ -23,10 +23,8 @@ package org.bytedeco.javacv;
 
 import org.bytedeco.javacpp.IntPointer;
 import org.bytedeco.javacpp.Pointer;
-import org.bytedeco.librealsense.global.RealSense;
 import org.bytedeco.librealsense2.*;
 import org.bytedeco.opencv.opencv_core.IplImage;
-import org.bytedeco.opencv.opencv_core.Point;
 import org.bytedeco.opencv.opencv_core.Size;
 
 import java.util.ArrayList;
@@ -85,20 +83,20 @@ public class RealSense2FrameGrabber extends FrameGrabber {
         return devices;
     }
 
-    public void clearStreams() {
+    public void disableAllStreams() {
         streams.clear();
     }
 
-    public List<RealSenseStream> getStreams() {
+    public List<RealSenseStream> getEnabledStreams() {
         return this.streams;
     }
 
-    public void addStream(RealSenseStream stream) {
+    public void enableStream(RealSenseStream stream) {
         streams.add(stream);
     }
 
-    public void addColorStream(int width, int height, int frameRate) {
-        addStream(new RealSenseStream(
+    public void enableColorStream(int width, int height, int frameRate) {
+        enableStream(new RealSenseStream(
                 RS2_STREAM_COLOR,
                 0,
                 new Size(width, height),
@@ -107,8 +105,8 @@ public class RealSense2FrameGrabber extends FrameGrabber {
         ));
     }
 
-    public void addDepthStream(int width, int height, int frameRate) {
-        addStream(new RealSenseStream(
+    public void enableDepthStream(int width, int height, int frameRate) {
+        enableStream(new RealSenseStream(
                 RS2_STREAM_DEPTH,
                 0,
                 new Size(width, height),
@@ -117,8 +115,8 @@ public class RealSense2FrameGrabber extends FrameGrabber {
         ));
     }
 
-    public void addIRStream(int width, int height, int frameRate) {
-        addStream(new RealSenseStream(
+    public void enableIRStream(int width, int height, int frameRate) {
+        enableStream(new RealSenseStream(
                 RS2_STREAM_INFRARED,
                 1,
                 new Size(width, height),

--- a/src/main/java/org/bytedeco/javacv/RealSense2FrameGrabber.java
+++ b/src/main/java/org/bytedeco/javacv/RealSense2FrameGrabber.java
@@ -160,7 +160,7 @@ public class RealSense2FrameGrabber extends FrameGrabber {
         // todo: set options (emitter)
 
         // set image width & height to largest stream
-        RealSenseStream largestStream = streams.stream().max(Comparator.comparing(RealSenseStream::getArea)).get();
+        RealSenseStream largestStream = getLargestStream();
         this.imageWidth = largestStream.size.width();
         this.imageHeight = largestStream.size.height();
 
@@ -233,6 +233,16 @@ public class RealSense2FrameGrabber extends FrameGrabber {
 
     public Frame grabIR(int streamIndex) throws Exception {
         return grabCVFrame(RS2_STREAM_INFRARED, streamIndex, IPL_DEPTH_8U, 1);
+    }
+
+    private RealSenseStream getLargestStream() {
+        RealSenseStream largest = streams.get(0);
+        for(RealSenseStream rs : streams) {
+            if(rs.size.area() > largest.size.area()) {
+                largest = rs;
+            }
+        }
+        return largest;
     }
 
     private Frame grabCVFrame(int streamType, int streamIndex, int iplDepth, int iplChannels) throws Exception {
@@ -453,10 +463,6 @@ public class RealSense2FrameGrabber extends FrameGrabber {
 
         public int getFormat() {
             return format;
-        }
-
-        protected int getArea() {
-            return size.area();
         }
     }
 

--- a/src/main/java/org/bytedeco/javacv/RealSense2FrameGrabber.java
+++ b/src/main/java/org/bytedeco/javacv/RealSense2FrameGrabber.java
@@ -109,12 +109,14 @@ public class RealSense2FrameGrabber extends FrameGrabber {
         checkError(error);
 
         // right ir stream
-        rs2_config_enable_stream(config, RS2_STREAM_INFRARED, 1, 640, 480, RS2_FORMAT_Y8, 30, error);
+        rs2_config_enable_stream(config, RS2_STREAM_INFRARED, 1, 1280, 720, RS2_FORMAT_Y8, 30, error);
         checkError(error);
 
         // left ir stream
         //rs2_config_enable_stream(config, RS2_STREAM_INFRARED, 2, 640, 480, RS2_FORMAT_Y8, 30, error);
         //checkError(error);
+
+        // todo: set options (emitter)
 
         // set image width & height
         this.imageWidth = 640;
@@ -174,7 +176,7 @@ public class RealSense2FrameGrabber extends FrameGrabber {
 
         // get depth frame if available
         rs2_frame frame = findFrameByStreamType(this.frameset, streamType, streamIndex);
-        if(frame == null)
+        if (frame == null)
             return null;
 
         // get frame data
@@ -210,7 +212,7 @@ public class RealSense2FrameGrabber extends FrameGrabber {
             StreamProfileData streamProfileData = getStreamProfileData(streamProfile);
 
             // compare stream type
-            if(streamType == streamProfileData.nativeStreamIndex.get() && searchIndex == index) {
+            if (streamType == streamProfileData.nativeStreamIndex.get() && searchIndex == index) {
                 result = frame;
                 break;
             }


### PR DESCRIPTION
As discussed in #1306 I have implemented a first version of a realsense2 framegrabber. The API is a bit different to the original realsense camera, so I also had to change the API of FrameGrabber.

At the moment it is possible to enable as many streams as the user wants and also specifying custom streams. New frames are loaded through the `trigger()` method, so this method has to be called **before** `grab()`, `grabIR()`, `grabColor()` and so on.

Besides reading the different frames, it is also possible to list all the available cameras.

I have also included a simple example on how to use the depth stream and the mouse to see the distance of the camera at the mouse click position.

The code has been tested with a RealSense D435 on MacOS, but should run with every rs2 compatible device.