### PR TITLE
Add ARM job to build for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ jobs:
          apt:
           packages: maven
        arch: arm64
-       language: shell
+       language: minimal
        script: 
           - "sudo add-apt-repository ppa:openjdk-r/ppa"
           - "sudo apt-get update"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,9 @@ jobs:
          apt:
           packages: maven
        arch: arm64
+       language: shell
        script: 
-          - "apt-cache search openjdk"
+          - "sudo apt install openjdk-8-jdk-headless; mvn install -B -U"
      - os: linux
        arch: amd64
        jdk: openjdk11

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ jobs:
          apt:
           packages: maven
        arch: arm64
-       language: java
+       language: shell
        script: 
           - "sudo add-apt-repository ppa:openjdk-r/ppa"
           - "sudo apt-get update"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ jobs:
      - os: linux
        addons:
          apt:
-          packages: maven openjdk-11-jdk-headless
+          packages: maven
        jdk: openjdk11
        arch: arm64
        language: java

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 dist: xenial
+sudo: required
 
 jobs:
   include:
@@ -9,7 +10,7 @@ jobs:
        arch: arm64
        language: java
        script: 
-          - "apt-cache search openjdk; mvn install -B -U"
+          - "apt-cache search openjdk
      - os: linux
        arch: amd64
        jdk: openjdk11

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ jobs:
           - "sudo apt-get update"
           - "sudo apt install openjdk-11-jdk-headless"
           - "mvn install -B -U"
-          - "mvn $MAVEN_PHASE -B -U -f platform -D javacpp.platform=linux-arm64"
+          - "mvn install -B -U -f platform -D javacpp.platform=linux-arm64"
      - os: linux
        arch: amd64
        jdk: openjdk11

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ jobs:
        arch: arm64
        language: shell
        script: 
-          - "sudo apt install openjdk-8-jdk-headless; mvn install -B -U"
+          - "sudo add-apt-repository ppa:openjdk-r/ppa; sudo apt-get update; apt-cache search openjdk; sudo apt install openjdk-lts; mvn install -B -U"
      - os: linux
        arch: amd64
        jdk: openjdk11

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ jobs:
        addons:
          apt:
           packages: maven openjdk-11-jdk-headless
+       jdk: openjdk11
        arch: arm64
        language: java
        script: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 dist: xenial
 sudo: required
+cache:
+  directories:
+    - $HOME/.m2
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ jobs:
          apt:
           packages: maven
        arch: arm64
-       language: java
        script: 
           - "apt-cache search openjdk"
      - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ jobs:
        addons:
          apt:
           packages: maven
-       jdk: openjdk11
+       jdk: openjdk12
        arch: arm64
        language: java
        script: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ jobs:
        arch: arm64
        language: java
        script: 
-          - "apt-cache search openjdk
+          - "apt-cache search openjdk"
      - os: linux
        arch: amd64
        jdk: openjdk11

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ jobs:
        arch: arm64
        language: shell
        script: 
-          - "sudo add-apt-repository ppa:openjdk-r/ppa; sudo apt-get update; apt-cache search openjdk; sudo apt install openjdk-lts; mvn install -B -U"
+          - "sudo add-apt-repository ppa:openjdk-r/ppa; sudo apt-get update; apt-cache search openjdk; sudo apt install openjdk-11-jdk-headless ; mvn install -B -U"
      - os: linux
        arch: amd64
        jdk: openjdk11

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,21 @@
 dist: xenial
-sudo: false
-language: java
-jdk:
-  - openjdk11
-cache:
-  directories:
-    - $HOME/.m2
-script:
-  - "echo '<settings><servers><server><id>sonatype-nexus-snapshots</id><username>${env.CI_DEPLOY_USERNAME}</username><password>${env.CI_DEPLOY_PASSWORD}</password></server></servers></settings>' > $HOME/settings.xml"
-  - "[[ $TRAVIS_PULL_REQUEST == 'false' ]] && export MAVEN_PHASE=deploy || export MAVEN_PHASE=install"
-  - "mvn $MAVEN_PHASE -B -U -s $HOME/settings.xml"
-  - "mvn $MAVEN_PHASE -B -U -s $HOME/settings.xml -f platform -D javacpp.platform=linux-x86_64"
+
+jobs:
+  include:
+     - os: linux
+       addons:
+         apt:
+          packages: maven openjdk-11-jdk-headless
+       arch: arm64
+       language: java
+       script: 
+          - "mvn install -B -U"
+     - os: linux
+       arch: amd64
+       jdk: openjdk11
+       language: java
+       script:
+          - "echo '<settings><servers><server><id>sonatype-nexus-snapshots</id><username>${env.CI_DEPLOY_USERNAME}</username><password>${env.CI_DEPLOY_PASSWORD}</password></server></servers></settings>' > $HOME/settings.xml"
+          - "[[ $TRAVIS_PULL_REQUEST == 'false' ]] && export MAVEN_PHASE=deploy || export MAVEN_PHASE=install"
+          - "mvn $MAVEN_PHASE -B -U -s $HOME/settings.xml"
+          - "mvn $MAVEN_PHASE -B -U -s $HOME/settings.xml -f platform -D javacpp.platform=linux-x86_64"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,11 @@ jobs:
        arch: arm64
        language: shell
        script: 
-          - "sudo add-apt-repository ppa:openjdk-r/ppa; sudo apt-get update; apt-cache search openjdk; sudo apt install openjdk-11-jdk-headless ; mvn install -B -U"
+          - "sudo add-apt-repository ppa:openjdk-r/ppa"
+          - "sudo apt-get update"
+          - "sudo apt install openjdk-11-jdk-headless"
+          - "mvn install -B -U"
+          - "mvn $MAVEN_PHASE -B -U -f platform -D javacpp.platform=linux-arm64"
      - os: linux
        arch: amd64
        jdk: openjdk11

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,10 @@ jobs:
        addons:
          apt:
           packages: maven
-       jdk: openjdk12
        arch: arm64
        language: java
        script: 
-          - "mvn install -B -U"
+          - "apt-cache search openjdk; mvn install -B -U"
      - os: linux
        arch: amd64
        jdk: openjdk11

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ jobs:
          apt:
           packages: maven
        arch: arm64
-       language: shell
+       language: java
        script: 
           - "sudo add-apt-repository ppa:openjdk-r/ppa"
           - "sudo apt-get update"


### PR DESCRIPTION
Follows on from the JavaCPP addition, can see from test output its running against ArmV8 which is good to see (that it actually does what was intended!)
Could easily be extended with openjdk 12 + 13 job instances too, maybe marked as failure OK

Had to mark it as a 'shell' type job rather than Java - I think they're still working on those images.