### PR TITLE
Fix error message print in FFmpegFrameGrabber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 
+ * Fix error message thrown from `FFmpegFrameRecorder.start()` not containing filename ([pull #1492](https://github.com/bytedeco/javacv/pull/1492))
  * Fix `FFmpegFrameFilter.pull()` not returning audio/video frames without audio/video filtergraph ([issue #1466](https://github.com/bytedeco/javacv/issues/1466))
  * Update `OpenCVFrameConverter.convertToOrgOpenCvCoreMat()` with new API to set the stride ([issue #1460](https://github.com/bytedeco/javacv/issues/1460))
  * Fix memory leaks and reduce memory fragmentation in `FFmpegFrameGrabber` and `FFmpegFrameRecorder` ([issue #1366](https://github.com/bytedeco/javacv/issues/1366))

--- a/src/main/java/org/bytedeco/javacv/FFmpegFrameRecorder.java
+++ b/src/main/java/org/bytedeco/javacv/FFmpegFrameRecorder.java
@@ -880,9 +880,10 @@ public class FFmpegFrameRecorder extends FrameRecorder {
         if (outputStream == null && (oformat.flags() & AVFMT_NOFILE) == 0) {
             AVIOContext pb = new AVIOContext(null);
             if ((ret = avio_open2(pb, filename, AVIO_FLAG_WRITE, null, options)) < 0) {
+                String errorMsg = "avio_open2 error() error " + ret + ": Could not open '" + filename + "'";
                 releaseUnsafe();
                 av_dict_free(options);
-                throw new Exception("avio_open2 error() error " + ret + ": Could not open '" + filename + "'");
+                throw new Exception(errorMsg);
             }
             oc.pb(pb);
         }
@@ -893,9 +894,10 @@ public class FFmpegFrameRecorder extends FrameRecorder {
         }
         /* write the stream header, if any */
         if ((ret = avformat_write_header(oc.metadata(metadata), options)) < 0) {
+            String errorMsg = "avformat_write_header error() error " + ret + ": Could not write header to '" + filename + "'";
             releaseUnsafe();
             av_dict_free(options);
-            throw new Exception("avformat_write_header error() error " + ret + ": Could not write header to '" + filename + "'");
+            throw new Exception(errorMsg);
         }
         av_dict_free(options);
 


### PR DESCRIPTION
Filename variable is set to null after method call 'releaseUnsafe'. In this case, error message will contain "null" instead of filename value. 
Create error message before 'releaseUnsafe'.