### PR TITLE
Correct JavaFxPlayVideoAndAudio sample to synchronize audio and video…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 
+ * Enhance audio and video synchronization of `JavaFxPlayVideoAndAudio` sample ([pull #1662](https://github.com/bytedeco/javacv/pull/1662))
  * Add `FrameGrabber.grabAtFrameRate()` to simulate a device or stream when reading from files ([pull #1659](https://github.com/bytedeco/javacv/pull/1659))
  * Update `FFmpegFrameGrabber` and `FFmpegFrameRecorder` with new `avcodec` API ([issue #1498](https://github.com/bytedeco/javacv/issues/1498))
  * Add new `Similarity` sample with PSNR and MSSIM ([pull #1622](https://github.com/bytedeco/javacv/pull/1622))

--- a/samples/JavaFxPlayVideoAndAudio.java
+++ b/samples/JavaFxPlayVideoAndAudio.java
@@ -97,10 +97,6 @@ public class JavaFxPlayVideoAndAudio extends Application {
                             outBuffer.putShort(val);
                         }
 
-                        /*
-                         * We need this because soundLine.write ignores
-                         * interruptions during writing.
-                         */
                         executor.submit(new Runnable() { public void run() {
                             soundLine.write(outBuffer.array(), 0, outBuffer.capacity());
                             outBuffer.clear();

--- a/samples/JavaFxPlayVideoAndAudio.java
+++ b/samples/JavaFxPlayVideoAndAudio.java
@@ -3,7 +3,6 @@ import java.nio.ShortBuffer;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javafx.application.Application;
@@ -27,10 +26,39 @@ import org.bytedeco.javacv.JavaFXFrameConverter;
  */
 public class JavaFxPlayVideoAndAudio extends Application {
 
+    private static class PlaybackTimer {
+        private Long startTime = -1L;
+        private final DataLine soundLine;
+
+        public PlaybackTimer(DataLine soundLine) {
+            this.soundLine = soundLine;
+        }
+
+        public PlaybackTimer() {
+            this.soundLine = null;
+        }
+
+        public void start() {
+            if (soundLine == null) {
+                startTime = System.nanoTime();
+            }
+        }
+
+        public long elapsedMicros() {
+            if (soundLine == null) {
+                if (startTime < 0) {
+                    throw new IllegalStateException("PlaybackTimer not initialized.");
+                }
+                return (System.nanoTime() - startTime) / 1000;
+            } else {
+                return soundLine.getMicrosecondPosition();
+            }
+        }
+    }
+
     private static final Logger LOG = Logger.getLogger(JavaFxPlayVideoAndAudio.class.getName());
 
     private static volatile Thread playThread;
-    private static final AtomicBoolean requestPlayThreadStop = new AtomicBoolean(false);
 
     public static void main(String[] args) {
         launch(args);
@@ -58,35 +86,65 @@ public class JavaFxPlayVideoAndAudio extends Application {
                 grabber.start();
                 primaryStage.setWidth(grabber.getImageWidth());
                 primaryStage.setHeight(grabber.getImageHeight());
-                final AudioFormat audioFormat = new AudioFormat(grabber.getSampleRate(), 16, grabber.getAudioChannels(), true, true);
+                final PlaybackTimer playbackTimer;
+                final SourceDataLine soundLine;
+                if (grabber.getAudioChannels() > 0) {
+                    final AudioFormat audioFormat = new AudioFormat(grabber.getSampleRate(), 16, grabber.getAudioChannels(), true, true);
 
-                final DataLine.Info info = new DataLine.Info(SourceDataLine.class, audioFormat);
-                final SourceDataLine soundLine = (SourceDataLine) AudioSystem.getLine(info);
-                soundLine.open(audioFormat);
-                soundLine.start();
+                    final DataLine.Info info = new DataLine.Info(SourceDataLine.class, audioFormat);
+                    soundLine = (SourceDataLine) AudioSystem.getLine(info);
+                    soundLine.open(audioFormat);
+                    soundLine.start();
+                    playbackTimer = new PlaybackTimer(soundLine);
+                } else {
+                    soundLine = null;
+                    playbackTimer = new PlaybackTimer();
+                }
 
                 final JavaFXFrameConverter converter = new JavaFXFrameConverter();
 
-                ExecutorService executor = Executors.newSingleThreadExecutor();
+                final ExecutorService audioExecutor = Executors.newSingleThreadExecutor();
+                final ExecutorService imageExecutor = Executors.newSingleThreadExecutor();
 
-                while (!Thread.interrupted() && !requestPlayThreadStop.get()) {
-                    Frame frame = grabber.grab();
+                final long maxReadAheadBufferMicros = 1000 * 1000L;
+
+                long lastTimeStamp = -1L;
+                while (!Thread.interrupted()) {
+                    final Frame frame = grabber.grab();
                     if (frame == null) {
                         break;
                     }
+                    if (lastTimeStamp < 0) {
+                        playbackTimer.start();
+                    }
+                    lastTimeStamp = frame.timestamp;
                     if (frame.image != null) {
-                        final Image image = converter.convert(frame);
-                        final long timeStampDeltaMicros = frame.timestamp - soundLine.getMicrosecondPosition();
-                        if (timeStampDeltaMicros > 0) {
-                            // We are ahead we will need to slow down to keep synced with audio
-                            long delayMillis = timeStampDeltaMicros / 1000L;
-                            // Wait for the next frame
-                            Thread.sleep(delayMillis);
-                        }
-                        Platform.runLater(new Runnable() { public void run() {
-                            imageView.setImage(image);
-                        }});
+                        final Frame imageFrame = frame.clone();
+
+                        imageExecutor.submit(new Runnable() {
+                            public void run() {
+                                final Image image = converter.convert(imageFrame);
+                                final long timeStampDeltaMicros = imageFrame.timestamp - playbackTimer.elapsedMicros();
+                                imageFrame.close();
+                                if (timeStampDeltaMicros > 0) {
+                                    final long delayMillis = timeStampDeltaMicros / 1000L;
+                                    try {
+                                        Thread.sleep(delayMillis);
+                                    } catch (InterruptedException e) {
+                                        e.printStackTrace();
+                                    }
+                                }
+                                Platform.runLater(new Runnable() {
+                                    public void run() {
+                                        imageView.setImage(image);
+                                    }
+                                });
+                            }
+                        });
                     } else if (frame.samples != null) {
+                        if (soundLine == null) {
+                            throw new IllegalStateException("Internal error: sound playback not initialized");
+                        }
                         final ShortBuffer channelSamplesShortBuffer = (ShortBuffer) frame.samples[0];
                         channelSamplesShortBuffer.rewind();
 
@@ -97,17 +155,34 @@ public class JavaFxPlayVideoAndAudio extends Application {
                             outBuffer.putShort(val);
                         }
 
-                        executor.submit(new Runnable() { public void run() {
-                            soundLine.write(outBuffer.array(), 0, outBuffer.capacity());
-                            outBuffer.clear();
-                        }});
+                        audioExecutor.submit(new Runnable() {
+                            public void run() {
+                                soundLine.write(outBuffer.array(), 0, outBuffer.capacity());
+                                outBuffer.clear();
+                            }
+                        });
+                    }
+                    final long timeStampDeltaMicros = frame.timestamp - playbackTimer.elapsedMicros();
+                    if (timeStampDeltaMicros > maxReadAheadBufferMicros) {
+                        Thread.sleep((timeStampDeltaMicros - maxReadAheadBufferMicros) / 1000);
                     }
                 }
-                executor.shutdownNow();
-                executor.awaitTermination(10, TimeUnit.SECONDS);
-                soundLine.stop();
+
+                if (!Thread.interrupted()) {
+                    long delay = (lastTimeStamp - playbackTimer.elapsedMicros()) / 1000 +
+                            Math.round(1 / grabber.getFrameRate() * 1000);
+                    Thread.sleep(Math.max(0, delay));
+                }
                 grabber.stop();
                 grabber.release();
+                if (soundLine != null) {
+                    soundLine.stop();
+                }
+                audioExecutor.shutdownNow();
+                audioExecutor.awaitTermination(10, TimeUnit.SECONDS);
+                imageExecutor.shutdownNow();
+                imageExecutor.awaitTermination(10, TimeUnit.SECONDS);
+
                 Platform.exit();
             } catch (Exception exception) {
                 LOG.log(Level.SEVERE, null, exception);
@@ -119,7 +194,7 @@ public class JavaFxPlayVideoAndAudio extends Application {
 
     @Override
     public void stop() {
-        requestPlayThreadStop.set(true);
+        playThread.interrupt();
     }
 
 }

--- a/samples/JavaFxPlayVideoAndAudio.java
+++ b/samples/JavaFxPlayVideoAndAudio.java
@@ -131,7 +131,7 @@ public class JavaFxPlayVideoAndAudio extends Application {
                                     try {
                                         Thread.sleep(delayMillis);
                                     } catch (InterruptedException e) {
-                                        e.printStackTrace();
+                                        Thread.currentThread().interrupt();
                                     }
                                 }
                                 Platform.runLater(new Runnable() {

--- a/samples/JavaFxPlayVideoAndAudio.java
+++ b/samples/JavaFxPlayVideoAndAudio.java
@@ -3,11 +3,11 @@ import java.nio.ShortBuffer;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javafx.application.Application;
 import javafx.application.Platform;
-import javafx.embed.swing.SwingFXUtils;
 import javafx.scene.Scene;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
@@ -19,16 +19,18 @@ import javax.sound.sampled.DataLine;
 import javax.sound.sampled.SourceDataLine;
 import org.bytedeco.javacv.FFmpegFrameGrabber;
 import org.bytedeco.javacv.Frame;
-import org.bytedeco.javacv.Java2DFrameConverter;
+import org.bytedeco.javacv.JavaFXFrameConverter;
 
 /**
  * @author Dmitriy Gerashenko <d.a.gerashenko@gmail.com>
+ * @author Jarek Sacha
  */
 public class JavaFxPlayVideoAndAudio extends Application {
 
     private static final Logger LOG = Logger.getLogger(JavaFxPlayVideoAndAudio.class.getName());
 
     private static volatile Thread playThread;
+    private static final AtomicBoolean requestPlayThreadStop = new AtomicBoolean(false);
 
     public static void main(String[] args) {
         launch(args);
@@ -63,17 +65,24 @@ public class JavaFxPlayVideoAndAudio extends Application {
                 soundLine.open(audioFormat);
                 soundLine.start();
 
-                final Java2DFrameConverter converter = new Java2DFrameConverter();
+                final JavaFXFrameConverter converter = new JavaFXFrameConverter();
 
                 ExecutorService executor = Executors.newSingleThreadExecutor();
 
-                while (!Thread.interrupted()) {
+                while (!Thread.interrupted() && !requestPlayThreadStop.get()) {
                     Frame frame = grabber.grab();
                     if (frame == null) {
                         break;
                     }
                     if (frame.image != null) {
-                        final Image image = SwingFXUtils.toFXImage(converter.convert(frame), null);
+                        final Image image = converter.convert(frame);
+                        final long timeStampDeltaMicros = frame.timestamp - soundLine.getMicrosecondPosition();
+                        if (timeStampDeltaMicros > 0) {
+                            // We are ahead we will need to slow down to keep synced with audio
+                            long delayMillis = timeStampDeltaMicros / 1000L;
+                            // Wait for the next frame
+                            Thread.sleep(delayMillis);
+                        }
                         Platform.runLater(new Runnable() { public void run() {
                             imageView.setImage(image);
                         }});
@@ -88,18 +97,14 @@ public class JavaFxPlayVideoAndAudio extends Application {
                             outBuffer.putShort(val);
                         }
 
-                        /**
+                        /*
                          * We need this because soundLine.write ignores
                          * interruptions during writing.
                          */
-                        try {
-                            executor.submit(new Runnable() { public void run() {
-                                soundLine.write(outBuffer.array(), 0, outBuffer.capacity());
-                                outBuffer.clear();
-                            }}).get();
-                        } catch (InterruptedException interruptedException) {
-                            Thread.currentThread().interrupt();
-                        }
+                        executor.submit(new Runnable() { public void run() {
+                            soundLine.write(outBuffer.array(), 0, outBuffer.capacity());
+                            outBuffer.clear();
+                        }});
                     }
                 }
                 executor.shutdownNow();
@@ -117,8 +122,8 @@ public class JavaFxPlayVideoAndAudio extends Application {
     }
 
     @Override
-    public void stop() throws Exception {
-        playThread.interrupt();
+    public void stop() {
+        requestPlayThreadStop.set(true);
     }
 
 }


### PR DESCRIPTION
… and prevent "dropping" of video frames

Before correction, video frames may be displayed in a quick succession resulting in a impression of dropped frames. Now video frames are synced to the timestamp of audio playback.