### PR TITLE
Ignore non-video and non-audio frames in FFmpegFrameRecorder.record

### DIFF
--- a/src/main/java/org/bytedeco/javacv/FFmpegFrameRecorder.java
+++ b/src/main/java/org/bytedeco/javacv/FFmpegFrameRecorder.java
@@ -1044,7 +1044,7 @@ public class FFmpegFrameRecorder extends FrameRecorder {
             picture.quality(video_c.global_quality());
             if ((ret = avcodec_send_frame(video_c, image == null || image.length == 0 ? null : picture)) < 0
                     && image != null && image.length != 0) {
-                 throw new Exception("avcodec_send_frame() error " + ret + ": Error sending a video frame for encoding.");
+                throw new Exception("avcodec_send_frame() error " + ret + ": Error sending a video frame for encoding.");
             }
             picture.pts(picture.pts() + 1); // magic required by libx264
 

--- a/src/main/java/org/bytedeco/javacv/FFmpegFrameRecorder.java
+++ b/src/main/java/org/bytedeco/javacv/FFmpegFrameRecorder.java
@@ -1047,7 +1047,8 @@ public class FFmpegFrameRecorder extends FrameRecorder {
             picture.quality(video_c.global_quality());
             if ((ret = avcodec_send_frame(video_c, image == null || image.length == 0 ? null : picture)) < 0
                     && image != null && image.length != 0) {
-                throw new Exception("avcodec_send_frame() error " + ret + ": Error sending a video frame for encoding.");
+                // Ignore errors to emulate the behavior of the old API
+                // throw new Exception("avcodec_send_frame() error " + ret + ": Error sending a video frame for encoding.");
             }
             picture.pts(picture.pts() + 1); // magic required by libx264
 


### PR DESCRIPTION
Issue: https://github.com/bytedeco/javacv/issues/1694

Recording a null frame will be considered as a flush packet and it signals end of the stream. This leads to all next frames will be ignored and error code AVERROR_EOF is returned.

Fix: Ignore non-video and non-audio frame on FFmpegFrameRecorder.record

Docs: https://ffmpeg.org/doxygen/3.3/group__lavc__decoding.html#ga9395cb802a5febf1f00df31497779169
Source Code: https://github.com/FFmpeg/FFmpeg/blob/25c8507818d8559a6654a5b30a0f8aae11a48181/libavcodec/encode.c#L375