### PR TITLE
Enable default color stream if none is enabled in RealSense2FrameGrabber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 
- * Enable as `videoStream` by default on `RealSense2FrameGrabber.start()` color, depth, and IR streams ([pull #1750](https://github.com/bytedeco/javacv/pull/1750))
+ * Enable by default on `RealSense2FrameGrabber.start()` all color, depth, and IR streams as `videoStream` ([pull #1750](https://github.com/bytedeco/javacv/pull/1750))
 
 ### February 11, 2022 version 1.5.7
  * Fix accuracy and latency issues with `FFmpegFrameGrabber.setVideoFrameNumber()` ([pull #1734](https://github.com/bytedeco/javacv/pull/1734))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 
+ * Enable as `videoStream` by default on `RealSense2FrameGrabber.start()` color, depth, and IR streams ([pull #1750](https://github.com/bytedeco/javacv/pull/1750))
+
 ### February 11, 2022 version 1.5.7
  * Fix accuracy and latency issues with `FFmpegFrameGrabber.setVideoFrameNumber()` ([pull #1734](https://github.com/bytedeco/javacv/pull/1734))
  * Add new `Frame.pictType` field set to `I`, `P`, `B`, etc by `FFmpegFrameGrabber` ([pull #1730](https://github.com/bytedeco/javacv/pull/1730))

--- a/src/main/java/org/bytedeco/javacv/RealSense2FrameGrabber.java
+++ b/src/main/java/org/bytedeco/javacv/RealSense2FrameGrabber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020 Florian Bruggisser, Samuel Audet
+ * Copyright (C) 2019-2022 Florian Bruggisser, Samuel Audet
  *
  * Licensed either under the Apache License, Version 2.0, or (at your option)
  * under the terms of the GNU General Public License as published by
@@ -184,14 +184,10 @@ public class RealSense2FrameGrabber extends FrameGrabber {
 
         // check if streams is not empty
         if (streams.isEmpty()) {
-            // enable color stream by default
-            enableStream(new RealSenseStream(
-                    RS2_STREAM_COLOR,
-                    0,
-                    new Size(0, 0),
-                    0,
-                    RS2_FORMAT_BGR8
-            ));
+            // enable color, depth and IR stream by default
+            enableColorStream(imageWidth, imageHeight, (int)frameRate);
+            enableDepthStream(imageWidth, imageHeight, (int)frameRate);
+            enableIRStream(imageWidth, imageHeight, (int)frameRate);
         }
 
         // enable streams
@@ -251,7 +247,8 @@ public class RealSense2FrameGrabber extends FrameGrabber {
 
     @Override
     public Frame grab() throws Exception {
-        RealSenseStream stream = streams.get(0);
+        int videoStreamId = Math.max(0, videoStream);
+        RealSenseStream stream = streams.get(videoStreamId);
 
         switch (stream.type) {
             case RS2_STREAM_DEPTH:

--- a/src/main/java/org/bytedeco/javacv/RealSense2FrameGrabber.java
+++ b/src/main/java/org/bytedeco/javacv/RealSense2FrameGrabber.java
@@ -183,8 +183,16 @@ public class RealSense2FrameGrabber extends FrameGrabber {
         this.config = createConfig();
 
         // check if streams is not empty
-        if (streams.isEmpty())
-            throw new Exception("No stream has been added to be enabled.");
+        if (streams.isEmpty()) {
+            // enable color stream by default
+            enableStream(new RealSenseStream(
+                    RS2_STREAM_COLOR,
+                    0,
+                    new Size(0, 0),
+                    0,
+                    RS2_FORMAT_BGR8
+            ));
+        }
 
         // enable streams
         for (RealSenseStream stream : streams) {


### PR DESCRIPTION
As mentioned in https://github.com/bytedeco/procamcalib/issues/26 this is a small fix for the `RealSense2FrameGrabber` to automatically enable the default color stream (in RGB8 format). The same behaviour is also implemented in the [RealSenseFrameGrabber](https://github.com/bytedeco/javacv/blob/master/src/main/java/org/bytedeco/javacv/RealSenseFrameGrabber.java#L271-L276).