### PR TITLE
Use `timeout` instead of `stimeout` for RTSP.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 
- * Update `FFmpegStreamingTimeout` sample using `timeout` instead of `stimeout` for RTSP ([pull #1758](https://github.com/bytedeco/javacv/pull/1758))
+ * Update `FFmpegStreamingTimeout` sample to use `timeout` instead of `stimeout` for RTSP ([pull #1758](https://github.com/bytedeco/javacv/pull/1758))
  * Restore static calls to `FFmpegFrameGrabber.tryLoad()` and `FFmpegFrameRecorder.tryLoad()` ([issue #1756](https://github.com/bytedeco/javacv/issues/1756))
  * Enable by default on `RealSense2FrameGrabber.start()` all color, depth, and IR streams as `videoStream` ([pull #1750](https://github.com/bytedeco/javacv/pull/1750))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 
+ * Update `FFmpegStreamingTimeout` sample using `timeout` instead of `stimeout` for RTSP ([pull #1758](https://github.com/bytedeco/javacv/pull/1758))
  * Restore static calls to `FFmpegFrameGrabber.tryLoad()` and `FFmpegFrameRecorder.tryLoad()` ([issue #1756](https://github.com/bytedeco/javacv/issues/1756))
  * Enable by default on `RealSense2FrameGrabber.start()` all color, depth, and IR streams as `videoStream` ([pull #1750](https://github.com/bytedeco/javacv/pull/1750))
 

--- a/samples/FFmpegStreamingTimeout.java
+++ b/samples/FFmpegStreamingTimeout.java
@@ -20,9 +20,12 @@ public class FFmpegStreamingTimeout {
      */
     private static enum TimeoutOption {
         /**
-         * Depends on protocol (FTP, HTTP, RTMP, SMB, SSH, TCP, UDP, or UNIX).
-         *
+         * Depends on protocol (FTP, HTTP, RTMP, RTSP, SMB, SSH, TCP, UDP, or UNIX).
          * http://ffmpeg.org/ffmpeg-all.html
+         *
+         * Specific for RTSP:
+         * Set socket TCP I/O timeout in microseconds.
+         * http://ffmpeg.org/ffmpeg-all.html#rtsp
          */
         TIMEOUT,
         /**
@@ -33,15 +36,7 @@ public class FFmpegStreamingTimeout {
          *
          * http://ffmpeg.org/ffmpeg-all.html#Protocols
          */
-        RW_TIMEOUT,
-        /**
-         * Protocols -> RTSP
-         *
-         * Set socket TCP I/O timeout in microseconds.
-         *
-         * http://ffmpeg.org/ffmpeg-all.html#rtsp
-         */
-        STIMEOUT;
+        RW_TIMEOUT;
 
         public String getKey() {
             return toString().toLowerCase();
@@ -61,24 +56,21 @@ public class FFmpegStreamingTimeout {
         try {
             FFmpegFrameGrabber grabber = new FFmpegFrameGrabber(SOURCE_RTSP);
             /**
-             * "timeout" - IS IGNORED when a network cable have been unplugged
-             * before a connection and sometimes when connection is lost.
-             *
              * "rw_timeout" - IS IGNORED when a network cable have been
              * unplugged before a connection but the option takes effect after a
              * connection was established.
              *
-             * "stimeout" - works fine.
+             * "timeout" - works fine.
              */
             grabber.setOption(
-                    TimeoutOption.STIMEOUT.getKey(),
+                    TimeoutOption.TIMEOUT.getKey(),
                     String.valueOf(TIMEOUT * 1000000)
             ); // In microseconds.
             grabber.start();
 
             Frame frame = null;
             /**
-             * When network is disabled (before brabber was started) grabber
+             * When network is disabled (before grabber was started) grabber
              * throws exception: "org.bytedeco.javacv.FrameGrabber$Exception:
              * avformat_open_input() error -138: Could not open input...".
              *


### PR DESCRIPTION
In FFmpeg 5.0 (bundled with javacv 1.5.7) the option for timeout has been renamed from `stimeout` to `timeout` when using the RTSP protocol. `stimeout` is not a valid option for the RTSP protocol anymore.

- Using it with `FFmpegFrameGrabber` has no effect.
- Using it with [ffmpeg program](http://bytedeco.org/javacpp-presets/ffmpeg/apidocs/org/bytedeco/ffmpeg/ffmpeg.html) results in error: 
  - Unrecognized option 'stimeout'
  
This PR updates the sample `FFmpegStreamingTimeout` to reflect this change and to make use of the option `timeout` instead.
Using `timeout` with javacv 1.5.7 works as expected for the RTSP sources I have tested with. 

For reference:  
https://github.com/FFmpeg/FFmpeg/commit/6f34f031908b8f16482e951ee5232116fb42b46a 