### PR TITLE
Update FrameGrabber.java to fix issue #1844

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 
+ * Add `FrameGrabber.resetStartTime()` to allow `grabAtFrameRate()` after operations such as seeking ([pull #1846](https://github.com/bytedeco/javacv/pull/1846))
+ * Add `FrameGrabber.videoSideData/audioSideData` properties and `FFmpegFrameGrabber.getDisplayRotation()` for convenience ([issue #1361](https://github.com/bytedeco/javacv/issues/1361))
  * Add to `FFmpegFrameGrabber` and `FFmpegFrameRecorder` constructors taking a `URL` for convenience and clarity
  * Fix incorrect call to `opencv_calib3d.stereoRectify()` in `ProjectiveDevice` ([issue #1802](https://github.com/bytedeco/javacv/issues/1802))
  * Retry after 10 ms when `av_read_frame()` returns `EAGAIN` in `FFmpegFrameGrabber.grabFrame()` ([issue #1784](https://github.com/bytedeco/javacv/issues/1784))

--- a/src/main/java/org/bytedeco/javacv/FrameGrabber.java
+++ b/src/main/java/org/bytedeco/javacv/FrameGrabber.java
@@ -490,6 +490,7 @@ public abstract class FrameGrabber implements Closeable {
     }
     public void setFrameNumber(int frameNumber) throws Exception {
         this.frameNumber = frameNumber;
+        startTime = 0;
     }
 
     public long getTimestamp() {
@@ -497,6 +498,7 @@ public abstract class FrameGrabber implements Closeable {
     }
     public void setTimestamp(long timestamp) throws Exception {
         this.timestamp = timestamp;
+        startTime = 0;
     }
 
     public int getMaxDelay() {

--- a/src/main/java/org/bytedeco/javacv/FrameGrabber.java
+++ b/src/main/java/org/bytedeco/javacv/FrameGrabber.java
@@ -490,7 +490,6 @@ public abstract class FrameGrabber implements Closeable {
     }
     public void setFrameNumber(int frameNumber) throws Exception {
         this.frameNumber = frameNumber;
-        startTime = 0;
     }
 
     public long getTimestamp() {
@@ -498,7 +497,6 @@ public abstract class FrameGrabber implements Closeable {
     }
     public void setTimestamp(long timestamp) throws Exception {
         this.timestamp = timestamp;
-        startTime = 0;
     }
 
     public int getMaxDelay() {
@@ -758,5 +756,9 @@ public abstract class FrameGrabber implements Closeable {
             }
         }
         return false;
+    }
+
+    public void resetStartTime() {
+        startTime = 0;
     }
 }


### PR DESCRIPTION
As mentioned in issue #1844, this is my fix to the problem.
When a seek of the source occurs with `FrameGrabber.setTimestamp()` or `FrameGrabber.setFrameNumber()`, the timer should be reset.

If the author of FrameGrabber.grabAtFrameRate(), @wangxi761, can take a look at them. It would be awesome. 