### PR TITLE
Introduce an EncodedPacketHooker for FFmpegFrameRecorder

### DIFF
--- a/src/main/java/org/bytedeco/javacv/EncodedPacketHooker.java
+++ b/src/main/java/org/bytedeco/javacv/EncodedPacketHooker.java
@@ -1,0 +1,18 @@
+package org.bytedeco.javacv;
+
+import org.bytedeco.ffmpeg.avcodec.AVPacket;
+
+/**
+ * Encoded packet hooker called by {@link FFmpegFrameRecorder}
+ */
+public interface EncodedPacketHooker {
+
+    /**
+     * Called when a packet has been encoded in record processing.
+     *
+     * @param packet the encoded packet.
+     * @param audio weather or not the packet is an audio packet.
+     */
+    void onPacketEncoded(AVPacket packet, boolean audio);
+
+}

--- a/src/main/java/org/bytedeco/javacv/FFmpegFrameRecorder.java
+++ b/src/main/java/org/bytedeco/javacv/FFmpegFrameRecorder.java
@@ -66,7 +66,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
-
 import org.bytedeco.javacpp.BytePointer;
 import org.bytedeco.javacpp.DoublePointer;
 import org.bytedeco.javacpp.FloatPointer;
@@ -83,7 +82,6 @@ import org.bytedeco.ffmpeg.avformat.*;
 import org.bytedeco.ffmpeg.avutil.*;
 import org.bytedeco.ffmpeg.swresample.*;
 import org.bytedeco.ffmpeg.swscale.*;
-
 import static org.bytedeco.ffmpeg.global.avcodec.*;
 import static org.bytedeco.ffmpeg.global.avdevice.*;
 import static org.bytedeco.ffmpeg.global.avformat.*;
@@ -92,30 +90,20 @@ import static org.bytedeco.ffmpeg.global.swresample.*;
 import static org.bytedeco.ffmpeg.global.swscale.*;
 
 /**
+ *
  * @author Samuel Audet
  */
 public class FFmpegFrameRecorder extends FrameRecorder {
 
     public static class Exception extends FrameRecorder.Exception {
-        public Exception(String message) {
-            super(message + " (For more details, make sure FFmpegLogCallback.set() has been called.)");
-        }
-
-        public Exception(String message, Throwable cause) {
-            super(message, cause);
-        }
+        public Exception(String message) { super(message + " (For more details, make sure FFmpegLogCallback.set() has been called.)"); }
+        public Exception(String message, Throwable cause) { super(message, cause); }
     }
 
-    public static FFmpegFrameRecorder createDefault(File f, int w, int h) throws Exception {
-        return new FFmpegFrameRecorder(f, w, h);
-    }
-
-    public static FFmpegFrameRecorder createDefault(String f, int w, int h) throws Exception {
-        return new FFmpegFrameRecorder(f, w, h);
-    }
+    public static FFmpegFrameRecorder createDefault(File f, int w, int h)   throws Exception { return new FFmpegFrameRecorder(f, w, h); }
+    public static FFmpegFrameRecorder createDefault(String f, int w, int h) throws Exception { return new FFmpegFrameRecorder(f, w, h); }
 
     private static Exception loadingException = null;
-
     public static void tryLoad() throws Exception {
         if (loadingException != null) {
             throw loadingException;
@@ -137,7 +125,7 @@ public class FFmpegFrameRecorder extends FrameRecorder {
                 avdevice_register_all();
             } catch (Throwable t) {
                 if (t instanceof Exception) {
-                    throw loadingException = (Exception) t;
+                    throw loadingException = (Exception)t;
                 } else {
                     throw loadingException = new Exception("Failed to load " + FFmpegFrameRecorder.class, t);
                 }
@@ -149,57 +137,48 @@ public class FFmpegFrameRecorder extends FrameRecorder {
         try {
             tryLoad();
 //            FFmpegLockCallback.init();
-        } catch (Exception ex) {
-        }
+        } catch (Exception ex) { }
     }
 
     public FFmpegFrameRecorder(URL url, int audioChannels) {
         this(url.toString(), 0, 0, audioChannels);
     }
-
     public FFmpegFrameRecorder(File file, int audioChannels) {
         this(file, 0, 0, audioChannels);
     }
-
     public FFmpegFrameRecorder(String filename, int audioChannels) {
         this(filename, 0, 0, audioChannels);
     }
-
     public FFmpegFrameRecorder(URL url, int imageWidth, int imageHeight) {
         this(url.toString(), imageWidth, imageHeight, 0);
     }
-
     public FFmpegFrameRecorder(File file, int imageWidth, int imageHeight) {
         this(file, imageWidth, imageHeight, 0);
     }
-
     public FFmpegFrameRecorder(String filename, int imageWidth, int imageHeight) {
         this(filename, imageWidth, imageHeight, 0);
     }
-
     public FFmpegFrameRecorder(URL url, int imageWidth, int imageHeight, int audioChannels) {
         this(url.toString(), imageWidth, imageHeight, audioChannels);
     }
-
     public FFmpegFrameRecorder(File file, int imageWidth, int imageHeight, int audioChannels) {
         this(file.getAbsolutePath(), imageWidth, imageHeight, audioChannels);
     }
-
     public FFmpegFrameRecorder(String filename, int imageWidth, int imageHeight, int audioChannels) {
-        this.filename = filename;
-        this.imageWidth = imageWidth;
-        this.imageHeight = imageHeight;
+        this.filename      = filename;
+        this.imageWidth    = imageWidth;
+        this.imageHeight   = imageHeight;
         this.audioChannels = audioChannels;
 
-        this.pixelFormat = AV_PIX_FMT_NONE;
-        this.videoCodec = AV_CODEC_ID_NONE;
-        this.videoBitrate = 400000;
-        this.frameRate = 30;
+        this.pixelFormat   = AV_PIX_FMT_NONE;
+        this.videoCodec    = AV_CODEC_ID_NONE;
+        this.videoBitrate  = 400000;
+        this.frameRate     = 30;
 
-        this.sampleFormat = AV_SAMPLE_FMT_NONE;
-        this.audioCodec = AV_CODEC_ID_NONE;
-        this.audioBitrate = 64000;
-        this.sampleRate = 44100;
+        this.sampleFormat  = AV_SAMPLE_FMT_NONE;
+        this.audioCodec    = AV_CODEC_ID_NONE;
+        this.audioBitrate  = 64000;
+        this.sampleRate    = 44100;
 
         this.interleaved = true;
     }
@@ -209,25 +188,21 @@ public class FFmpegFrameRecorder extends FrameRecorder {
         this.outputStream = outputStream;
         this.closeOutputStream = true;
     }
-
     public FFmpegFrameRecorder(OutputStream outputStream, int imageWidth, int imageHeight) {
         this(outputStream.toString(), imageWidth, imageHeight);
         this.outputStream = outputStream;
         this.closeOutputStream = true;
     }
-
     public FFmpegFrameRecorder(OutputStream outputStream, int imageWidth, int imageHeight, int audioChannels) {
         this(outputStream.toString(), imageWidth, imageHeight, audioChannels);
         this.outputStream = outputStream;
         this.closeOutputStream = true;
     }
-
     public void release() throws Exception {
         synchronized (org.bytedeco.ffmpeg.global.avcodec.class) {
             releaseUnsafe();
         }
     }
-
     public synchronized void releaseUnsafe() throws Exception {
         started = false;
 
@@ -345,25 +320,23 @@ public class FFmpegFrameRecorder extends FrameRecorder {
             }
         }
     }
-
-    @Override
-    protected void finalize() throws Throwable {
+    @Override protected void finalize() throws Throwable {
         super.finalize();
         release();
     }
 
-    static Map<Pointer, OutputStream> outputStreams = Collections.synchronizedMap(new HashMap<Pointer, OutputStream>());
+    static Map<Pointer,OutputStream> outputStreams = Collections.synchronizedMap(new HashMap<Pointer,OutputStream>());
 
     static class WriteCallback extends Write_packet_Pointer_BytePointer_int {
-        @Override
-        public int call(Pointer opaque, BytePointer buf, int buf_size) {
+        @Override public int call(Pointer opaque, BytePointer buf, int buf_size) {
             try {
                 byte[] b = new byte[buf_size];
                 OutputStream os = outputStreams.get(opaque);
                 buf.get(b, 0, buf_size);
                 os.write(b, 0, buf_size);
                 return buf_size;
-            } catch (Throwable t) {
+            }
+            catch (Throwable t) {
                 System.err.println("Error on OutputStream.write(): " + t);
                 return -1;
             }
@@ -374,13 +347,13 @@ public class FFmpegFrameRecorder extends FrameRecorder {
 
     static class SeekCallback extends Seek_Pointer_long_int {
 
-        @Override
-        public long call(Pointer opaque, long offset, int whence) {
+        @Override public long call(Pointer opaque, long offset, int whence) {
             try {
                 OutputStream os = outputStreams.get(opaque);
-                ((Seekable) os).seek(offset, whence);
+                ((Seekable)os).seek(offset, whence);
                 return 0;
-            } catch (Throwable t) {
+            }
+            catch (Throwable t) {
                 System.err.println("Error on OutputStream.seek(): " + t);
                 return -1;
             }
@@ -412,10 +385,9 @@ public class FFmpegFrameRecorder extends FrameRecorder {
     private SwrContext samples_convert_ctx;
     private int samples_channels, samples_format, samples_rate;
     private PointerPointer plane_ptr, plane_ptr2;
-    protected AVPacket video_pkt, audio_pkt;
+    private AVPacket video_pkt, audio_pkt;
     private int[] got_video_packet, got_audio_packet;
     private AVFormatContext ifmt_ctx;
-
     private EncodedPacketHooker encodedPacketHooker;
 
     private volatile boolean started = false;
@@ -423,48 +395,23 @@ public class FFmpegFrameRecorder extends FrameRecorder {
     public boolean isCloseOutputStream() {
         return closeOutputStream;
     }
-
     public void setCloseOutputStream(boolean closeOutputStream) {
         this.closeOutputStream = closeOutputStream;
     }
 
-    @Override
-    public int getFrameNumber() {
-        return picture == null ? super.getFrameNumber() : (int) picture.pts();
+    @Override public int getFrameNumber() {
+        return picture == null ? super.getFrameNumber() : (int)picture.pts();
+    }
+    @Override public void setFrameNumber(int frameNumber) {
+        if (picture == null) { super.setFrameNumber(frameNumber); } else { picture.pts(frameNumber); }
     }
 
-    @Override
-    public void setFrameNumber(int frameNumber) {
-        if (picture == null) {
-            super.setFrameNumber(frameNumber);
-        } else {
-            picture.pts(frameNumber);
-        }
-    }
-
-    /**
-     * Returns best guess for timestamp in microseconds...
-     */
-    @Override
-    public long getTimestamp() {
+    /** Returns best guess for timestamp in microseconds... */
+    @Override public long getTimestamp() {
         return Math.round(getFrameNumber() * 1000000L / getFrameRate());
     }
-
-    @Override
-    public void setTimestamp(long timestamp) {
-        setFrameNumber((int) Math.round(timestamp * getFrameRate() / 1000000L));
-    }
-
-    public void start(AVFormatContext inputFormatContext) throws Exception {
-        this.ifmt_ctx = inputFormatContext;
-        start();
-    }
-
-    @Override
-    public void start() throws Exception {
-        synchronized (org.bytedeco.ffmpeg.global.avcodec.class) {
-            startUnsafe();
-        }
+    @Override public void setTimestamp(long timestamp)  {
+        setFrameNumber((int)Math.round(timestamp * getFrameRate() / 1000000L));
     }
 
     public EncodedPacketHooker getEncodedPacketHooker() {
@@ -473,6 +420,17 @@ public class FFmpegFrameRecorder extends FrameRecorder {
 
     public void setEncodedPacketHooker(EncodedPacketHooker encodedPacketHooker) {
         this.encodedPacketHooker = encodedPacketHooker;
+    }
+
+    public void start(AVFormatContext inputFormatContext) throws Exception {
+        this.ifmt_ctx = inputFormatContext;
+        start();
+    }
+
+    @Override public void start() throws Exception {
+        synchronized (org.bytedeco.ffmpeg.global.avcodec.class) {
+            startUnsafe();
+        }
     }
 
     public synchronized void startUnsafe() throws Exception {
@@ -494,7 +452,7 @@ public class FFmpegFrameRecorder extends FrameRecorder {
             audio_c = null;
             video_st = null;
             audio_st = null;
-            plane_ptr = new PointerPointer(AVFrame.AV_NUM_DATA_POINTERS).retainReference();
+            plane_ptr  = new PointerPointer(AVFrame.AV_NUM_DATA_POINTERS).retainReference();
             plane_ptr2 = new PointerPointer(AVFrame.AV_NUM_DATA_POINTERS).retainReference();
             video_pkt = new AVPacket().retainReference();
             audio_pkt = new AVPacket().retainReference();
@@ -541,7 +499,7 @@ public class FFmpegFrameRecorder extends FrameRecorder {
                         inpVideoStream = inputStream;
                         videoCodec = inpVideoStream.codecpar().codec_id();
                         if (inpVideoStream.r_frame_rate().num() != AV_NOPTS_VALUE && inpVideoStream.r_frame_rate().den() != 0) {
-                            frameRate = (inpVideoStream.r_frame_rate().num()) * 1.0d / (inpVideoStream.r_frame_rate().den());
+                            frameRate = (inpVideoStream.r_frame_rate().num())*1.0d / (inpVideoStream.r_frame_rate().den());
                         }
 
                     } else if (inputStream.codecpar().codec_type() == AVMEDIA_TYPE_AUDIO) {
@@ -599,9 +557,9 @@ public class FFmpegFrameRecorder extends FrameRecorder {
                         throw new Exception("avcodec_parameters_copy() error " + ret + ": Failed to copy video stream codec parameters from input to output");
                     }
 
-                    videoBitrate = (int) inpVideoStream.codecpar().bit_rate();
+                    videoBitrate = (int)inpVideoStream.codecpar().bit_rate();
                     pixelFormat = inpVideoStream.codecpar().format();
-                    aspectRatio = inpVideoStream.codecpar().sample_aspect_ratio().num() * 1.0d / inpVideoStream.codecpar().sample_aspect_ratio().den();
+                    aspectRatio = inpVideoStream.codecpar().sample_aspect_ratio().num()*1.0d/ inpVideoStream.codecpar().sample_aspect_ratio().den();
 //                videoQuality = inpVideoStream.codecpar().global_quality();
                     video_c.codec_tag(0);
                 }
@@ -639,13 +597,13 @@ public class FFmpegFrameRecorder extends FrameRecorder {
                 }
                 if (videoQuality >= 0) {
                     video_c.flags(video_c.flags() | AV_CODEC_FLAG_QSCALE);
-                    video_c.global_quality((int) Math.round(FF_QP2LAMBDA * videoQuality));
+                    video_c.global_quality((int)Math.round(FF_QP2LAMBDA * videoQuality));
                 }
 
                 if (pixelFormat != AV_PIX_FMT_NONE) {
                     video_c.pix_fmt(pixelFormat);
                 } else if (video_c.codec_id() == AV_CODEC_ID_RAWVIDEO || video_c.codec_id() == AV_CODEC_ID_PNG ||
-                        video_c.codec_id() == AV_CODEC_ID_HUFFYUV || video_c.codec_id() == AV_CODEC_ID_FFV1) {
+                        video_c.codec_id() == AV_CODEC_ID_HUFFYUV  || video_c.codec_id() == AV_CODEC_ID_FFV1) {
                     video_c.pix_fmt(AV_PIX_FMT_RGB32);   // appropriate for common lossless formats
                 } else if (video_c.codec_id() == AV_CODEC_ID_JPEGLS) {
                     video_c.pix_fmt(AV_PIX_FMT_BGR24);
@@ -781,31 +739,20 @@ public class FFmpegFrameRecorder extends FrameRecorder {
 //            audio_st.codec().time_base(time_base); // "deprecated", but this is actually required
                 switch (audio_c.sample_fmt()) {
                     case AV_SAMPLE_FMT_U8:
-                    case AV_SAMPLE_FMT_U8P:
-                        audio_c.bits_per_raw_sample(8);
-                        break;
+                    case AV_SAMPLE_FMT_U8P:  audio_c.bits_per_raw_sample(8);  break;
                     case AV_SAMPLE_FMT_S16:
-                    case AV_SAMPLE_FMT_S16P:
-                        audio_c.bits_per_raw_sample(16);
-                        break;
+                    case AV_SAMPLE_FMT_S16P: audio_c.bits_per_raw_sample(16); break;
                     case AV_SAMPLE_FMT_S32:
-                    case AV_SAMPLE_FMT_S32P:
-                        audio_c.bits_per_raw_sample(32);
-                        break;
+                    case AV_SAMPLE_FMT_S32P: audio_c.bits_per_raw_sample(32); break;
                     case AV_SAMPLE_FMT_FLT:
-                    case AV_SAMPLE_FMT_FLTP:
-                        audio_c.bits_per_raw_sample(32);
-                        break;
+                    case AV_SAMPLE_FMT_FLTP: audio_c.bits_per_raw_sample(32); break;
                     case AV_SAMPLE_FMT_DBL:
-                    case AV_SAMPLE_FMT_DBLP:
-                        audio_c.bits_per_raw_sample(64);
-                        break;
-                    default:
-                        assert false;
+                    case AV_SAMPLE_FMT_DBLP: audio_c.bits_per_raw_sample(64); break;
+                    default: assert false;
                 }
                 if (audioQuality >= 0) {
                     audio_c.flags(audio_c.flags() | AV_CODEC_FLAG_QSCALE);
-                    audio_c.global_quality((int) Math.round(FF_QP2LAMBDA * audioQuality));
+                    audio_c.global_quality((int)Math.round(FF_QP2LAMBDA * audioQuality));
                 }
 
                 // some formats want stream headers to be separate
@@ -927,8 +874,8 @@ public class FFmpegFrameRecorder extends FrameRecorder {
                     audio_input_frame_size = audio_c.frame_size();
                 }
                 //int bufferSize = audio_input_frame_size * audio_c.bits_per_raw_sample()/8 * audio_c.channels();
-                int planes = av_sample_fmt_is_planar(audio_c.sample_fmt()) != 0 ? (int) audio_c.channels() : 1;
-                int data_size = av_samples_get_buffer_size((IntPointer) null, audio_c.channels(),
+                int planes = av_sample_fmt_is_planar(audio_c.sample_fmt()) != 0 ? (int)audio_c.channels() : 1;
+                int data_size = av_samples_get_buffer_size((IntPointer)null, audio_c.channels(),
                         audio_input_frame_size, audio_c.sample_fmt(), 1) / planes;
                 samples_out = new BytePointer[planes];
                 for (int i = 0; i < samples_out.length; i++) {
@@ -998,9 +945,8 @@ public class FFmpegFrameRecorder extends FrameRecorder {
     public synchronized void flush() throws Exception {
         synchronized (oc) {
             /* flush all the buffers */
-            while (video_st != null && ifmt_ctx == null && recordImage(0, 0, 0, 0, 0, AV_PIX_FMT_NONE, (Buffer[]) null))
-                ;
-            while (audio_st != null && ifmt_ctx == null && recordSamples(0, 0, (Buffer[]) null)) ;
+            while (video_st != null && ifmt_ctx == null && recordImage(0, 0, 0, 0, 0, AV_PIX_FMT_NONE, (Buffer[])null));
+            while (audio_st != null && ifmt_ctx == null && recordSamples(0, 0, (Buffer[])null));
 
             if (interleaved && (video_st != null || audio_st != null)) {
                 av_interleaved_write_frame(oc, null);
@@ -1023,14 +969,12 @@ public class FFmpegFrameRecorder extends FrameRecorder {
         }
     }
 
-    @Override
-    public void record(Frame frame) throws Exception {
-        record(frame, frame != null && frame.opaque instanceof AVFrame ? ((AVFrame) frame.opaque).format() : AV_PIX_FMT_NONE);
+    @Override public void record(Frame frame) throws Exception {
+        record(frame, frame != null && frame.opaque instanceof AVFrame ? ((AVFrame)frame.opaque).format() : AV_PIX_FMT_NONE);
     }
-
     public synchronized void record(Frame frame, int pixelFormat) throws Exception {
         if (frame == null || (frame.image == null && frame.samples == null && frame.data == null)) {
-            recordImage(0, 0, 0, 0, 0, pixelFormat, (Buffer[]) null);
+            recordImage(0, 0, 0, 0, 0, pixelFormat, (Buffer[])null);
         } else {
             if (frame.image != null) {
                 frame.keyFrame = recordImage(frame.imageWidth, frame.imageHeight, frame.imageDepth,
@@ -1042,7 +986,7 @@ public class FFmpegFrameRecorder extends FrameRecorder {
         }
     }
 
-    public synchronized boolean recordImage(int width, int height, int depth, int channels, int stride, int pixelFormat, Buffer... image) throws Exception {
+    public synchronized boolean recordImage(int width, int height, int depth, int channels, int stride, int pixelFormat, Buffer ... image) throws Exception {
         try (PointerScope scope = new PointerScope()) {
 
             if (video_st == null) {
@@ -1060,7 +1004,7 @@ public class FFmpegFrameRecorder extends FrameRecorder {
             } else {
                 int step = stride * Math.abs(depth) / 8;
                 BytePointer data = image[0] instanceof ByteBuffer
-                        ? new BytePointer((ByteBuffer) image[0]).position(0)
+                        ? new BytePointer((ByteBuffer)image[0]).position(0)
                         : new BytePointer(new Pointer(image[0]).position(0));
 
                 if (pixelFormat == AV_PIX_FMT_NONE) {
@@ -1089,7 +1033,7 @@ public class FFmpegFrameRecorder extends FrameRecorder {
                     img_convert_ctx = sws_getCachedContext(img_convert_ctx, width, height, pixelFormat,
                             video_c.width(), video_c.height(), video_c.pix_fmt(),
                             imageScalingFlags != 0 ? imageScalingFlags : SWS_BILINEAR,
-                            null, null, (DoublePointer) null);
+                            null, null, (DoublePointer)null);
                     if (img_convert_ctx == null) {
                         throw new Exception("sws_getCachedContext() error: Cannot initialize the conversion context.");
                     }
@@ -1163,11 +1107,10 @@ public class FFmpegFrameRecorder extends FrameRecorder {
         }
     }
 
-    public boolean recordSamples(Buffer... samples) throws Exception {
+    public boolean recordSamples(Buffer ... samples) throws Exception {
         return recordSamples(0, 0, samples);
     }
-
-    public synchronized boolean recordSamples(int sampleRate, int audioChannels, Buffer... samples) throws Exception {
+    public synchronized boolean recordSamples(int sampleRate, int audioChannels, Buffer ... samples) throws Exception {
         try (PointerScope scope = new PointerScope()) {
 
             if (audio_st == null) {
@@ -1179,9 +1122,9 @@ public class FFmpegFrameRecorder extends FrameRecorder {
 
             if (samples == null && samples_out[0].position() > 0) {
                 // Typically samples_out[0].limit() is double the audio_input_frame_size --> sampleDivisor = 2
-                double sampleDivisor = Math.floor((int) Math.min(samples_out[0].limit(), Integer.MAX_VALUE) / audio_input_frame_size);
-                writeSamples((int) Math.floor((int) samples_out[0].position() / sampleDivisor));
-                return writeFrame((AVFrame) null);
+                double sampleDivisor = Math.floor((int)Math.min(samples_out[0].limit(), Integer.MAX_VALUE) / audio_input_frame_size);
+                writeSamples((int)Math.floor((int)samples_out[0].position() / sampleDivisor));
+                return writeFrame((AVFrame)null);
             }
 
             int ret;
@@ -1203,9 +1146,9 @@ public class FFmpegFrameRecorder extends FrameRecorder {
                 inputFormat = samples.length > 1 ? AV_SAMPLE_FMT_U8P : AV_SAMPLE_FMT_U8;
                 inputDepth = 1;
                 for (int i = 0; i < samples.length; i++) {
-                    ByteBuffer b = (ByteBuffer) samples[i];
+                    ByteBuffer b = (ByteBuffer)samples[i];
                     if (samples_in[i] instanceof BytePointer && samples_in[i].capacity() >= inputSize && b.hasArray()) {
-                        ((BytePointer) samples_in[i]).position(0).put(b.array(), b.position(), inputSize);
+                        ((BytePointer)samples_in[i]).position(0).put(b.array(), b.position(), inputSize);
                     } else {
                         if (samples_in[i] != null) {
                             samples_in[i].releaseReference();
@@ -1217,9 +1160,9 @@ public class FFmpegFrameRecorder extends FrameRecorder {
                 inputFormat = samples.length > 1 ? AV_SAMPLE_FMT_S16P : AV_SAMPLE_FMT_S16;
                 inputDepth = 2;
                 for (int i = 0; i < samples.length; i++) {
-                    ShortBuffer b = (ShortBuffer) samples[i];
+                    ShortBuffer b = (ShortBuffer)samples[i];
                     if (samples_in[i] instanceof ShortPointer && samples_in[i].capacity() >= inputSize && b.hasArray()) {
-                        ((ShortPointer) samples_in[i]).position(0).put(b.array(), samples[i].position(), inputSize);
+                        ((ShortPointer)samples_in[i]).position(0).put(b.array(), samples[i].position(), inputSize);
                     } else {
                         if (samples_in[i] != null) {
                             samples_in[i].releaseReference();
@@ -1231,9 +1174,9 @@ public class FFmpegFrameRecorder extends FrameRecorder {
                 inputFormat = samples.length > 1 ? AV_SAMPLE_FMT_S32P : AV_SAMPLE_FMT_S32;
                 inputDepth = 4;
                 for (int i = 0; i < samples.length; i++) {
-                    IntBuffer b = (IntBuffer) samples[i];
+                    IntBuffer b = (IntBuffer)samples[i];
                     if (samples_in[i] instanceof IntPointer && samples_in[i].capacity() >= inputSize && b.hasArray()) {
-                        ((IntPointer) samples_in[i]).position(0).put(b.array(), samples[i].position(), inputSize);
+                        ((IntPointer)samples_in[i]).position(0).put(b.array(), samples[i].position(), inputSize);
                     } else {
                         if (samples_in[i] != null) {
                             samples_in[i].releaseReference();
@@ -1245,9 +1188,9 @@ public class FFmpegFrameRecorder extends FrameRecorder {
                 inputFormat = samples.length > 1 ? AV_SAMPLE_FMT_FLTP : AV_SAMPLE_FMT_FLT;
                 inputDepth = 4;
                 for (int i = 0; i < samples.length; i++) {
-                    FloatBuffer b = (FloatBuffer) samples[i];
+                    FloatBuffer b = (FloatBuffer)samples[i];
                     if (samples_in[i] instanceof FloatPointer && samples_in[i].capacity() >= inputSize && b.hasArray()) {
-                        ((FloatPointer) samples_in[i]).position(0).put(b.array(), b.position(), inputSize);
+                        ((FloatPointer)samples_in[i]).position(0).put(b.array(), b.position(), inputSize);
                     } else {
                         if (samples_in[i] != null) {
                             samples_in[i].releaseReference();
@@ -1259,9 +1202,9 @@ public class FFmpegFrameRecorder extends FrameRecorder {
                 inputFormat = samples.length > 1 ? AV_SAMPLE_FMT_DBLP : AV_SAMPLE_FMT_DBL;
                 inputDepth = 8;
                 for (int i = 0; i < samples.length; i++) {
-                    DoubleBuffer b = (DoubleBuffer) samples[i];
+                    DoubleBuffer b = (DoubleBuffer)samples[i];
                     if (samples_in[i] instanceof DoublePointer && samples_in[i].capacity() >= inputSize && b.hasArray()) {
-                        ((DoublePointer) samples_in[i]).position(0).put(b.array(), b.position(), inputSize);
+                        ((DoublePointer)samples_in[i]).position(0).put(b.array(), b.position(), inputSize);
                     } else {
                         if (samples_in[i] != null) {
                             samples_in[i].releaseReference();
@@ -1291,8 +1234,8 @@ public class FFmpegFrameRecorder extends FrameRecorder {
                         limit((samples_in[i].position() + inputSize) * inputDepth);
             }
             while (true) {
-                int inputCount = (int) Math.min(samples != null ? (samples_in[0].limit() - samples_in[0].position()) / (inputChannels * inputDepth) : 0, Integer.MAX_VALUE);
-                int outputCount = (int) Math.min((samples_out[0].limit() - samples_out[0].position()) / (outputChannels * outputDepth), Integer.MAX_VALUE);
+                int inputCount = (int)Math.min(samples != null ? (samples_in[0].limit() - samples_in[0].position()) / (inputChannels * inputDepth) : 0, Integer.MAX_VALUE);
+                int outputCount = (int)Math.min((samples_out[0].limit() - samples_out[0].position()) / (outputChannels * outputDepth), Integer.MAX_VALUE);
                 inputCount = Math.min(inputCount, (outputCount * sampleRate + audio_c.sample_rate() - 1) / audio_c.sample_rate());
                 for (int i = 0; samples != null && i < samples.length; i++) {
                     plane_ptr.put(i, samples_in[i]);
@@ -1316,7 +1259,7 @@ public class FFmpegFrameRecorder extends FrameRecorder {
                     writeSamples(audio_input_frame_size);
                 }
             }
-            return samples != null ? frame.key_frame() != 0 : writeFrame((AVFrame) null);
+            return samples != null ? frame.key_frame() != 0 : writeFrame((AVFrame)null);
 
         }
     }
@@ -1327,14 +1270,14 @@ public class FFmpegFrameRecorder extends FrameRecorder {
         }
 
         frame.nb_samples(nb_samples);
-        avcodec_fill_audio_frame(frame, audio_c.channels(), audio_c.sample_fmt(), samples_out[0], (int) samples_out[0].position(), 0);
+        avcodec_fill_audio_frame(frame, audio_c.channels(), audio_c.sample_fmt(), samples_out[0], (int)samples_out[0].position(), 0);
         for (int i = 0; i < samples_out.length; i++) {
             int linesize = 0;
             if (samples_out[0].position() > 0 && samples_out[0].position() < samples_out[0].limit()) {
                 // align the end of the buffer to a 32-byte boundary as sometimes required by FFmpeg
-                linesize = ((int) samples_out[i].position() + 31) & ~31;
+                linesize = ((int)samples_out[i].position() + 31) & ~31;
             } else {
-                linesize = (int) Math.min(samples_out[i].limit(), Integer.MAX_VALUE);
+                linesize = (int)Math.min(samples_out[i].limit(), Integer.MAX_VALUE);
             }
 
             frame.data(i, samples_out[i].position(0));
@@ -1391,6 +1334,22 @@ public class FFmpegFrameRecorder extends FrameRecorder {
         return got_audio_packet[0] != 0;
     }
 
+    protected void packetEncoded(int mediaType, AVPacket avPacket) throws Exception {
+        if (encodedPacketHooker != null) {
+            switch (mediaType) {
+                case AVMEDIA_TYPE_AUDIO:
+                    encodedPacketHooker.onPacketEncoded(avPacket, true);
+                    break;
+
+                case AVMEDIA_TYPE_VIDEO:
+                    encodedPacketHooker.onPacketEncoded(avPacket, false);
+                    break;
+            }
+        }
+
+        writePacket(mediaType, avPacket);
+    }
+
     private void writePacket(int mediaType, AVPacket avPacket) throws Exception {
         AVStream avStream = (mediaType == AVMEDIA_TYPE_VIDEO) ? video_st : (mediaType == AVMEDIA_TYPE_AUDIO) ? audio_st : null;
         String mediaTypeStr = (mediaType == AVMEDIA_TYPE_VIDEO) ? "video" : (mediaType == AVMEDIA_TYPE_AUDIO) ? "audio" : "unsupported media stream type";
@@ -1412,21 +1371,6 @@ public class FFmpegFrameRecorder extends FrameRecorder {
         av_packet_unref(avPacket);
     }
 
-    /**
-     * Call encodedPacketHooker if set, and then write packet to output.
-     *
-     * @param mediaType media type, value is one of avutil.AVMEDIA_TYPE_XXXX
-     * @param avPacket the encoded packet which want to be written to output
-     *
-     * @throws Exception
-     */
-    private void packetEncoded(int mediaType, AVPacket avPacket) throws Exception {
-        if (encodedPacketHooker != null && (mediaType == AVMEDIA_TYPE_AUDIO || mediaType == AVMEDIA_TYPE_VIDEO))
-            encodedPacketHooker.onPacketEncoded(avPacket, mediaType == AVMEDIA_TYPE_AUDIO);
-
-        writePacket(mediaType, avPacket);
-    }
-
     public synchronized boolean recordPacket(AVPacket pkt) throws Exception {
         if (ifmt_ctx == null) {
             throw new Exception("No input format context (Has start(AVFormatContext) been called?)");
@@ -1441,7 +1385,7 @@ public class FFmpegFrameRecorder extends FrameRecorder {
 
         AVStream in_stream = ifmt_ctx.streams(pkt.stream_index());
 /**
- * Repair the problem of error decoding and playback caused by the absence of dts/pts 
+ * Repair the problem of error decoding and playback caused by the absence of dts/pts
  * in the output audio/video file or audio/video stream,
  * Comment out this line of code so that PTS / DTS can specify the timestamp manually.
  */
@@ -1451,14 +1395,14 @@ public class FFmpegFrameRecorder extends FrameRecorder {
         if (in_stream.codecpar().codec_type() == AVMEDIA_TYPE_VIDEO && video_st != null) {
             pkt.stream_index(video_st.index());
             pkt.duration((int) av_rescale_q(pkt.duration(), in_stream.time_base(), video_st.time_base()));
-            pkt.pts(av_rescale_q_rnd(pkt.pts(), in_stream.time_base(), video_st.time_base(), (AV_ROUND_NEAR_INF | AV_ROUND_PASS_MINMAX)));//Increase pts calculation
-            pkt.dts(av_rescale_q_rnd(pkt.dts(), in_stream.time_base(), video_st.time_base(), (AV_ROUND_NEAR_INF | AV_ROUND_PASS_MINMAX)));//Increase dts calculation
+            pkt.pts(av_rescale_q_rnd(pkt.pts(), in_stream.time_base(), video_st.time_base(),(AV_ROUND_NEAR_INF | AV_ROUND_PASS_MINMAX)));//Increase pts calculation
+            pkt.dts(av_rescale_q_rnd(pkt.dts(), in_stream.time_base(), video_st.time_base(),(AV_ROUND_NEAR_INF | AV_ROUND_PASS_MINMAX)));//Increase dts calculation
             packetEncoded(AVMEDIA_TYPE_VIDEO, pkt);
         } else if (in_stream.codecpar().codec_type() == AVMEDIA_TYPE_AUDIO && audio_st != null && (audioChannels > 0)) {
             pkt.stream_index(audio_st.index());
             pkt.duration((int) av_rescale_q(pkt.duration(), in_stream.time_base(), audio_st.time_base()));
-            pkt.pts(av_rescale_q_rnd(pkt.pts(), in_stream.time_base(), audio_st.time_base(), (AV_ROUND_NEAR_INF | AV_ROUND_PASS_MINMAX)));//Increase pts calculation
-            pkt.dts(av_rescale_q_rnd(pkt.dts(), in_stream.time_base(), audio_st.time_base(), (AV_ROUND_NEAR_INF | AV_ROUND_PASS_MINMAX)));//Increase dts calculation
+            pkt.pts(av_rescale_q_rnd(pkt.pts(), in_stream.time_base(), audio_st.time_base(),(AV_ROUND_NEAR_INF | AV_ROUND_PASS_MINMAX)));//Increase pts calculation
+            pkt.dts(av_rescale_q_rnd(pkt.dts(), in_stream.time_base(), audio_st.time_base(),(AV_ROUND_NEAR_INF | AV_ROUND_PASS_MINMAX)));//Increase dts calculation
             packetEncoded(AVMEDIA_TYPE_AUDIO, pkt);
         }
 

--- a/src/main/java/org/bytedeco/javacv/FFmpegFrameRecorder.java
+++ b/src/main/java/org/bytedeco/javacv/FFmpegFrameRecorder.java
@@ -66,6 +66,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+
 import org.bytedeco.javacpp.BytePointer;
 import org.bytedeco.javacpp.DoublePointer;
 import org.bytedeco.javacpp.FloatPointer;
@@ -82,6 +83,7 @@ import org.bytedeco.ffmpeg.avformat.*;
 import org.bytedeco.ffmpeg.avutil.*;
 import org.bytedeco.ffmpeg.swresample.*;
 import org.bytedeco.ffmpeg.swscale.*;
+
 import static org.bytedeco.ffmpeg.global.avcodec.*;
 import static org.bytedeco.ffmpeg.global.avdevice.*;
 import static org.bytedeco.ffmpeg.global.avformat.*;
@@ -90,20 +92,30 @@ import static org.bytedeco.ffmpeg.global.swresample.*;
 import static org.bytedeco.ffmpeg.global.swscale.*;
 
 /**
- *
  * @author Samuel Audet
  */
 public class FFmpegFrameRecorder extends FrameRecorder {
 
     public static class Exception extends FrameRecorder.Exception {
-        public Exception(String message) { super(message + " (For more details, make sure FFmpegLogCallback.set() has been called.)"); }
-        public Exception(String message, Throwable cause) { super(message, cause); }
+        public Exception(String message) {
+            super(message + " (For more details, make sure FFmpegLogCallback.set() has been called.)");
+        }
+
+        public Exception(String message, Throwable cause) {
+            super(message, cause);
+        }
     }
 
-    public static FFmpegFrameRecorder createDefault(File f, int w, int h)   throws Exception { return new FFmpegFrameRecorder(f, w, h); }
-    public static FFmpegFrameRecorder createDefault(String f, int w, int h) throws Exception { return new FFmpegFrameRecorder(f, w, h); }
+    public static FFmpegFrameRecorder createDefault(File f, int w, int h) throws Exception {
+        return new FFmpegFrameRecorder(f, w, h);
+    }
+
+    public static FFmpegFrameRecorder createDefault(String f, int w, int h) throws Exception {
+        return new FFmpegFrameRecorder(f, w, h);
+    }
 
     private static Exception loadingException = null;
+
     public static void tryLoad() throws Exception {
         if (loadingException != null) {
             throw loadingException;
@@ -125,7 +137,7 @@ public class FFmpegFrameRecorder extends FrameRecorder {
                 avdevice_register_all();
             } catch (Throwable t) {
                 if (t instanceof Exception) {
-                    throw loadingException = (Exception)t;
+                    throw loadingException = (Exception) t;
                 } else {
                     throw loadingException = new Exception("Failed to load " + FFmpegFrameRecorder.class, t);
                 }
@@ -137,48 +149,57 @@ public class FFmpegFrameRecorder extends FrameRecorder {
         try {
             tryLoad();
 //            FFmpegLockCallback.init();
-        } catch (Exception ex) { }
+        } catch (Exception ex) {
+        }
     }
 
     public FFmpegFrameRecorder(URL url, int audioChannels) {
         this(url.toString(), 0, 0, audioChannels);
     }
+
     public FFmpegFrameRecorder(File file, int audioChannels) {
         this(file, 0, 0, audioChannels);
     }
+
     public FFmpegFrameRecorder(String filename, int audioChannels) {
         this(filename, 0, 0, audioChannels);
     }
+
     public FFmpegFrameRecorder(URL url, int imageWidth, int imageHeight) {
         this(url.toString(), imageWidth, imageHeight, 0);
     }
+
     public FFmpegFrameRecorder(File file, int imageWidth, int imageHeight) {
         this(file, imageWidth, imageHeight, 0);
     }
+
     public FFmpegFrameRecorder(String filename, int imageWidth, int imageHeight) {
         this(filename, imageWidth, imageHeight, 0);
     }
+
     public FFmpegFrameRecorder(URL url, int imageWidth, int imageHeight, int audioChannels) {
         this(url.toString(), imageWidth, imageHeight, audioChannels);
     }
+
     public FFmpegFrameRecorder(File file, int imageWidth, int imageHeight, int audioChannels) {
         this(file.getAbsolutePath(), imageWidth, imageHeight, audioChannels);
     }
+
     public FFmpegFrameRecorder(String filename, int imageWidth, int imageHeight, int audioChannels) {
-        this.filename      = filename;
-        this.imageWidth    = imageWidth;
-        this.imageHeight   = imageHeight;
+        this.filename = filename;
+        this.imageWidth = imageWidth;
+        this.imageHeight = imageHeight;
         this.audioChannels = audioChannels;
 
-        this.pixelFormat   = AV_PIX_FMT_NONE;
-        this.videoCodec    = AV_CODEC_ID_NONE;
-        this.videoBitrate  = 400000;
-        this.frameRate     = 30;
+        this.pixelFormat = AV_PIX_FMT_NONE;
+        this.videoCodec = AV_CODEC_ID_NONE;
+        this.videoBitrate = 400000;
+        this.frameRate = 30;
 
-        this.sampleFormat  = AV_SAMPLE_FMT_NONE;
-        this.audioCodec    = AV_CODEC_ID_NONE;
-        this.audioBitrate  = 64000;
-        this.sampleRate    = 44100;
+        this.sampleFormat = AV_SAMPLE_FMT_NONE;
+        this.audioCodec = AV_CODEC_ID_NONE;
+        this.audioBitrate = 64000;
+        this.sampleRate = 44100;
 
         this.interleaved = true;
     }
@@ -188,21 +209,25 @@ public class FFmpegFrameRecorder extends FrameRecorder {
         this.outputStream = outputStream;
         this.closeOutputStream = true;
     }
+
     public FFmpegFrameRecorder(OutputStream outputStream, int imageWidth, int imageHeight) {
         this(outputStream.toString(), imageWidth, imageHeight);
         this.outputStream = outputStream;
         this.closeOutputStream = true;
     }
+
     public FFmpegFrameRecorder(OutputStream outputStream, int imageWidth, int imageHeight, int audioChannels) {
         this(outputStream.toString(), imageWidth, imageHeight, audioChannels);
         this.outputStream = outputStream;
         this.closeOutputStream = true;
     }
+
     public void release() throws Exception {
         synchronized (org.bytedeco.ffmpeg.global.avcodec.class) {
             releaseUnsafe();
         }
     }
+
     public synchronized void releaseUnsafe() throws Exception {
         started = false;
 
@@ -320,23 +345,25 @@ public class FFmpegFrameRecorder extends FrameRecorder {
             }
         }
     }
-    @Override protected void finalize() throws Throwable {
+
+    @Override
+    protected void finalize() throws Throwable {
         super.finalize();
         release();
     }
 
-    static Map<Pointer,OutputStream> outputStreams = Collections.synchronizedMap(new HashMap<Pointer,OutputStream>());
+    static Map<Pointer, OutputStream> outputStreams = Collections.synchronizedMap(new HashMap<Pointer, OutputStream>());
 
     static class WriteCallback extends Write_packet_Pointer_BytePointer_int {
-        @Override public int call(Pointer opaque, BytePointer buf, int buf_size) {
+        @Override
+        public int call(Pointer opaque, BytePointer buf, int buf_size) {
             try {
                 byte[] b = new byte[buf_size];
                 OutputStream os = outputStreams.get(opaque);
                 buf.get(b, 0, buf_size);
                 os.write(b, 0, buf_size);
                 return buf_size;
-            }
-            catch (Throwable t) {
+            } catch (Throwable t) {
                 System.err.println("Error on OutputStream.write(): " + t);
                 return -1;
             }
@@ -347,13 +374,13 @@ public class FFmpegFrameRecorder extends FrameRecorder {
 
     static class SeekCallback extends Seek_Pointer_long_int {
 
-        @Override public long call(Pointer opaque, long offset, int whence) {
+        @Override
+        public long call(Pointer opaque, long offset, int whence) {
             try {
                 OutputStream os = outputStreams.get(opaque);
-                ((Seekable)os).seek(offset, whence);
+                ((Seekable) os).seek(offset, whence);
                 return 0;
-            }
-            catch (Throwable t) {
+            } catch (Throwable t) {
                 System.err.println("Error on OutputStream.seek(): " + t);
                 return -1;
             }
@@ -385,32 +412,47 @@ public class FFmpegFrameRecorder extends FrameRecorder {
     private SwrContext samples_convert_ctx;
     private int samples_channels, samples_format, samples_rate;
     private PointerPointer plane_ptr, plane_ptr2;
-    private AVPacket video_pkt, audio_pkt;
+    protected AVPacket video_pkt, audio_pkt;
     private int[] got_video_packet, got_audio_packet;
     private AVFormatContext ifmt_ctx;
+
+    private EncodedPacketHooker encodedPacketHooker;
 
     private volatile boolean started = false;
 
     public boolean isCloseOutputStream() {
         return closeOutputStream;
     }
+
     public void setCloseOutputStream(boolean closeOutputStream) {
         this.closeOutputStream = closeOutputStream;
     }
 
-    @Override public int getFrameNumber() {
-        return picture == null ? super.getFrameNumber() : (int)picture.pts();
-    }
-    @Override public void setFrameNumber(int frameNumber) {
-        if (picture == null) { super.setFrameNumber(frameNumber); } else { picture.pts(frameNumber); }
+    @Override
+    public int getFrameNumber() {
+        return picture == null ? super.getFrameNumber() : (int) picture.pts();
     }
 
-    /** Returns best guess for timestamp in microseconds... */
-    @Override public long getTimestamp() {
+    @Override
+    public void setFrameNumber(int frameNumber) {
+        if (picture == null) {
+            super.setFrameNumber(frameNumber);
+        } else {
+            picture.pts(frameNumber);
+        }
+    }
+
+    /**
+     * Returns best guess for timestamp in microseconds...
+     */
+    @Override
+    public long getTimestamp() {
         return Math.round(getFrameNumber() * 1000000L / getFrameRate());
     }
-    @Override public void setTimestamp(long timestamp)  {
-        setFrameNumber((int)Math.round(timestamp * getFrameRate() / 1000000L));
+
+    @Override
+    public void setTimestamp(long timestamp) {
+        setFrameNumber((int) Math.round(timestamp * getFrameRate() / 1000000L));
     }
 
     public void start(AVFormatContext inputFormatContext) throws Exception {
@@ -418,92 +460,101 @@ public class FFmpegFrameRecorder extends FrameRecorder {
         start();
     }
 
-    @Override public void start() throws Exception {
+    @Override
+    public void start() throws Exception {
         synchronized (org.bytedeco.ffmpeg.global.avcodec.class) {
             startUnsafe();
         }
     }
 
+    public EncodedPacketHooker getEncodedPacketHooker() {
+        return encodedPacketHooker;
+    }
+
+    public void setEncodedPacketHooker(EncodedPacketHooker encodedPacketHooker) {
+        this.encodedPacketHooker = encodedPacketHooker;
+    }
+
     public synchronized void startUnsafe() throws Exception {
         try (PointerScope scope = new PointerScope()) {
 
-        if (oc != null && !oc.isNull()) {
-            throw new Exception("start() has already been called: Call stop() before calling start() again.");
-        }
-
-        int ret;
-        picture = null;
-        tmp_picture = null;
-        picture_buf = null;
-        frame = null;
-        video_outbuf = null;
-        audio_outbuf = null;
-        oc = new AVFormatContext(null);
-        video_c = null;
-        audio_c = null;
-        video_st = null;
-        audio_st = null;
-        plane_ptr  = new PointerPointer(AVFrame.AV_NUM_DATA_POINTERS).retainReference();
-        plane_ptr2 = new PointerPointer(AVFrame.AV_NUM_DATA_POINTERS).retainReference();
-        video_pkt = new AVPacket().retainReference();
-        audio_pkt = new AVPacket().retainReference();
-        got_video_packet = new int[1];
-        got_audio_packet = new int[1];
-
-        /* auto detect the output format from the name. */
-        String format_name = format == null || format.length() == 0 ? null : format;
-        if ((oformat = av_guess_format(format_name, filename, null)) == null) {
-            int proto = filename.indexOf("://");
-            if (proto > 0) {
-                format_name = filename.substring(0, proto);
+            if (oc != null && !oc.isNull()) {
+                throw new Exception("start() has already been called: Call stop() before calling start() again.");
             }
+
+            int ret;
+            picture = null;
+            tmp_picture = null;
+            picture_buf = null;
+            frame = null;
+            video_outbuf = null;
+            audio_outbuf = null;
+            oc = new AVFormatContext(null);
+            video_c = null;
+            audio_c = null;
+            video_st = null;
+            audio_st = null;
+            plane_ptr = new PointerPointer(AVFrame.AV_NUM_DATA_POINTERS).retainReference();
+            plane_ptr2 = new PointerPointer(AVFrame.AV_NUM_DATA_POINTERS).retainReference();
+            video_pkt = new AVPacket().retainReference();
+            audio_pkt = new AVPacket().retainReference();
+            got_video_packet = new int[1];
+            got_audio_packet = new int[1];
+
+            /* auto detect the output format from the name. */
+            String format_name = format == null || format.length() == 0 ? null : format;
             if ((oformat = av_guess_format(format_name, filename, null)) == null) {
-                throw new Exception("av_guess_format() error: Could not guess output format for \"" + filename + "\" and " + format + " format.");
+                int proto = filename.indexOf("://");
+                if (proto > 0) {
+                    format_name = filename.substring(0, proto);
+                }
+                if ((oformat = av_guess_format(format_name, filename, null)) == null) {
+                    throw new Exception("av_guess_format() error: Could not guess output format for \"" + filename + "\" and " + format + " format.");
+                }
             }
-        }
-        format_name = oformat.name().getString();
+            format_name = oformat.name().getString();
 
-        /* allocate the output media context */
-        if (avformat_alloc_output_context2(oc, null, format_name, filename) < 0) {
-            throw new Exception("avformat_alloc_context2() error:\tCould not allocate format context");
-        }
+            /* allocate the output media context */
+            if (avformat_alloc_output_context2(oc, null, format_name, filename) < 0) {
+                throw new Exception("avformat_alloc_context2() error:\tCould not allocate format context");
+            }
 
-        if (outputStream != null) {
-            avio = avio_alloc_context(new BytePointer(av_malloc(4096)), 4096, 1, oc, null, writeCallback, outputStream instanceof Seekable ? seekCallback : null);
-            oc.pb(avio);
+            if (outputStream != null) {
+                avio = avio_alloc_context(new BytePointer(av_malloc(4096)), 4096, 1, oc, null, writeCallback, outputStream instanceof Seekable ? seekCallback : null);
+                oc.pb(avio);
 
-            filename = outputStream.toString();
-            outputStreams.put(oc, outputStream);
-        }
-        oc.oformat(oformat);
-        oc.url(new BytePointer(av_malloc(filename.getBytes().length + 1)).putString(filename));
-        oc.max_delay(maxDelay);
+                filename = outputStream.toString();
+                outputStreams.put(oc, outputStream);
+            }
+            oc.oformat(oformat);
+            oc.url(new BytePointer(av_malloc(filename.getBytes().length + 1)).putString(filename));
+            oc.max_delay(maxDelay);
 
         /* add the audio and video streams using the format codecs
            and initialize the codecs */
-        AVStream inpVideoStream = null, inpAudioStream = null;
-        if (ifmt_ctx != null) {
-            // get input video and audio stream indices from ifmt_ctx
-            for (int idx = 0; idx < ifmt_ctx.nb_streams(); idx++) {
-                AVStream inputStream = ifmt_ctx.streams(idx);
-                if (inputStream.codecpar().codec_type() == AVMEDIA_TYPE_VIDEO) {
-                    inpVideoStream = inputStream;
-                    videoCodec = inpVideoStream.codecpar().codec_id();
-                    if (inpVideoStream.r_frame_rate().num() != AV_NOPTS_VALUE && inpVideoStream.r_frame_rate().den() != 0) {
-                        frameRate = (inpVideoStream.r_frame_rate().num())*1.0d / (inpVideoStream.r_frame_rate().den());
-                    }
+            AVStream inpVideoStream = null, inpAudioStream = null;
+            if (ifmt_ctx != null) {
+                // get input video and audio stream indices from ifmt_ctx
+                for (int idx = 0; idx < ifmt_ctx.nb_streams(); idx++) {
+                    AVStream inputStream = ifmt_ctx.streams(idx);
+                    if (inputStream.codecpar().codec_type() == AVMEDIA_TYPE_VIDEO) {
+                        inpVideoStream = inputStream;
+                        videoCodec = inpVideoStream.codecpar().codec_id();
+                        if (inpVideoStream.r_frame_rate().num() != AV_NOPTS_VALUE && inpVideoStream.r_frame_rate().den() != 0) {
+                            frameRate = (inpVideoStream.r_frame_rate().num()) * 1.0d / (inpVideoStream.r_frame_rate().den());
+                        }
 
-                } else if (inputStream.codecpar().codec_type() == AVMEDIA_TYPE_AUDIO) {
-                    inpAudioStream = inputStream;
-                    audioCodec = inpAudioStream.codecpar().codec_id();
+                    } else if (inputStream.codecpar().codec_type() == AVMEDIA_TYPE_AUDIO) {
+                        inpAudioStream = inputStream;
+                        audioCodec = inpAudioStream.codecpar().codec_id();
+                    }
                 }
             }
-        }
 
-        if (imageWidth > 0 && imageHeight > 0) {
-            if (videoCodec == AV_CODEC_ID_NONE) {
-                videoCodec = oformat.video_codec();
-            }
+            if (imageWidth > 0 && imageHeight > 0) {
+                if (videoCodec == AV_CODEC_ID_NONE) {
+                    videoCodec = oformat.video_codec();
+                }
 //            if (videoCodec != AV_CODEC_ID_NONE) {
 //                oformat.video_codec(videoCodec);
 //            } else if ("flv".equals(format_name)) {
@@ -516,147 +567,147 @@ public class FFmpegFrameRecorder extends FrameRecorder {
 //                oformat.video_codec(AV_CODEC_ID_HUFFYUV);
 //            }
 
-            /* find the video encoder */
-            if ((video_codec = avcodec_find_encoder_by_name(videoCodecName)) == null &&
-                (video_codec = avcodec_find_encoder(videoCodec)) == null) {
-                releaseUnsafe();
-                throw new Exception("avcodec_find_encoder() error: Video codec not found.");
-            }
+                /* find the video encoder */
+                if ((video_codec = avcodec_find_encoder_by_name(videoCodecName)) == null &&
+                        (video_codec = avcodec_find_encoder(videoCodec)) == null) {
+                    releaseUnsafe();
+                    throw new Exception("avcodec_find_encoder() error: Video codec not found.");
+                }
 //            oformat.video_codec(video_codec.id());
 
-            AVRational frame_rate = av_d2q(frameRate, 1001000);
-            AVRational supported_framerates = video_codec.supported_framerates();
-            if (supported_framerates != null) {
-                int idx = av_find_nearest_q_idx(frame_rate, supported_framerates);
-                frame_rate = supported_framerates.position(idx);
-            }
-
-            /* add a video output stream */
-            if ((video_st = avformat_new_stream(oc, null)) == null) {
-                releaseUnsafe();
-                throw new Exception("avformat_new_stream() error: Could not allocate video stream.");
-            }
-
-            if ((video_c = avcodec_alloc_context3(video_codec)) == null) {
-                releaseUnsafe();
-                throw new Exception("avcodec_alloc_context3() error: Could not allocate video encoding context.");
-            }
-
-            if (inpVideoStream != null) {
-                if ((ret = avcodec_parameters_copy(video_st.codecpar(), inpVideoStream.codecpar())) < 0) {
-                    releaseUnsafe();
-                    throw new Exception("avcodec_parameters_copy() error " + ret + ": Failed to copy video stream codec parameters from input to output");
+                AVRational frame_rate = av_d2q(frameRate, 1001000);
+                AVRational supported_framerates = video_codec.supported_framerates();
+                if (supported_framerates != null) {
+                    int idx = av_find_nearest_q_idx(frame_rate, supported_framerates);
+                    frame_rate = supported_framerates.position(idx);
                 }
 
-                videoBitrate = (int)inpVideoStream.codecpar().bit_rate();
-                pixelFormat = inpVideoStream.codecpar().format();
-                aspectRatio = inpVideoStream.codecpar().sample_aspect_ratio().num()*1.0d/ inpVideoStream.codecpar().sample_aspect_ratio().den();
+                /* add a video output stream */
+                if ((video_st = avformat_new_stream(oc, null)) == null) {
+                    releaseUnsafe();
+                    throw new Exception("avformat_new_stream() error: Could not allocate video stream.");
+                }
+
+                if ((video_c = avcodec_alloc_context3(video_codec)) == null) {
+                    releaseUnsafe();
+                    throw new Exception("avcodec_alloc_context3() error: Could not allocate video encoding context.");
+                }
+
+                if (inpVideoStream != null) {
+                    if ((ret = avcodec_parameters_copy(video_st.codecpar(), inpVideoStream.codecpar())) < 0) {
+                        releaseUnsafe();
+                        throw new Exception("avcodec_parameters_copy() error " + ret + ": Failed to copy video stream codec parameters from input to output");
+                    }
+
+                    videoBitrate = (int) inpVideoStream.codecpar().bit_rate();
+                    pixelFormat = inpVideoStream.codecpar().format();
+                    aspectRatio = inpVideoStream.codecpar().sample_aspect_ratio().num() * 1.0d / inpVideoStream.codecpar().sample_aspect_ratio().den();
 //                videoQuality = inpVideoStream.codecpar().global_quality();
-                video_c.codec_tag(0);
-            }
+                    video_c.codec_tag(0);
+                }
 
-            video_c.codec_id(video_codec.id());
-            video_c.codec_type(AVMEDIA_TYPE_VIDEO);
+                video_c.codec_id(video_codec.id());
+                video_c.codec_type(AVMEDIA_TYPE_VIDEO);
 
 
-            /* put sample parameters */
-            video_c.bit_rate(videoBitrate);
-            /* resolution must be a multiple of two. Scale height to maintain the aspect ratio. */
-            if (imageWidth % 2 == 1) {
-                int roundedWidth = imageWidth + 1;
-                imageHeight = (roundedWidth * imageHeight + imageWidth / 2) / imageWidth;
-                imageWidth = roundedWidth;
-            }
-            video_c.width(imageWidth);
-            video_c.height(imageHeight);
-            if (aspectRatio > 0) {
-                AVRational r = av_d2q(aspectRatio, 255);
-                video_c.sample_aspect_ratio(r);
-                video_st.sample_aspect_ratio(r);
-            }
+                /* put sample parameters */
+                video_c.bit_rate(videoBitrate);
+                /* resolution must be a multiple of two. Scale height to maintain the aspect ratio. */
+                if (imageWidth % 2 == 1) {
+                    int roundedWidth = imageWidth + 1;
+                    imageHeight = (roundedWidth * imageHeight + imageWidth / 2) / imageWidth;
+                    imageWidth = roundedWidth;
+                }
+                video_c.width(imageWidth);
+                video_c.height(imageHeight);
+                if (aspectRatio > 0) {
+                    AVRational r = av_d2q(aspectRatio, 255);
+                    video_c.sample_aspect_ratio(r);
+                    video_st.sample_aspect_ratio(r);
+                }
             /* time base: this is the fundamental unit of time (in seconds) in terms
                of which frame timestamps are represented. for fixed-fps content,
                timebase should be 1/framerate and timestamp increments should be
                identically 1. */
-            AVRational time_base = av_inv_q(frame_rate);
-            video_c.time_base(time_base);
-            video_st.time_base(time_base);
-            video_st.avg_frame_rate(frame_rate);
+                AVRational time_base = av_inv_q(frame_rate);
+                video_c.time_base(time_base);
+                video_st.time_base(time_base);
+                video_st.avg_frame_rate(frame_rate);
 //            video_st.codec().time_base(time_base); // "deprecated", but this is actually required
-            if (gopSize >= 0) {
-                video_c.gop_size(gopSize); /* emit one intra frame every gopSize frames at most */
-            }
-            if (videoQuality >= 0) {
-                video_c.flags(video_c.flags() | AV_CODEC_FLAG_QSCALE);
-                video_c.global_quality((int)Math.round(FF_QP2LAMBDA * videoQuality));
-            }
+                if (gopSize >= 0) {
+                    video_c.gop_size(gopSize); /* emit one intra frame every gopSize frames at most */
+                }
+                if (videoQuality >= 0) {
+                    video_c.flags(video_c.flags() | AV_CODEC_FLAG_QSCALE);
+                    video_c.global_quality((int) Math.round(FF_QP2LAMBDA * videoQuality));
+                }
 
-            if (pixelFormat != AV_PIX_FMT_NONE) {
-                video_c.pix_fmt(pixelFormat);
-            } else if (video_c.codec_id() == AV_CODEC_ID_RAWVIDEO || video_c.codec_id() == AV_CODEC_ID_PNG ||
-                       video_c.codec_id() == AV_CODEC_ID_HUFFYUV  || video_c.codec_id() == AV_CODEC_ID_FFV1) {
-                video_c.pix_fmt(AV_PIX_FMT_RGB32);   // appropriate for common lossless formats
-            } else if (video_c.codec_id() == AV_CODEC_ID_JPEGLS) {
-                video_c.pix_fmt(AV_PIX_FMT_BGR24);
-            } else if (video_c.codec_id() == AV_CODEC_ID_MJPEG || video_c.codec_id() == AV_CODEC_ID_MJPEGB) {
-                video_c.pix_fmt(AV_PIX_FMT_YUVJ420P);
-            } else {
-                video_c.pix_fmt(AV_PIX_FMT_YUV420P); // lossy, but works with about everything
-            }
+                if (pixelFormat != AV_PIX_FMT_NONE) {
+                    video_c.pix_fmt(pixelFormat);
+                } else if (video_c.codec_id() == AV_CODEC_ID_RAWVIDEO || video_c.codec_id() == AV_CODEC_ID_PNG ||
+                        video_c.codec_id() == AV_CODEC_ID_HUFFYUV || video_c.codec_id() == AV_CODEC_ID_FFV1) {
+                    video_c.pix_fmt(AV_PIX_FMT_RGB32);   // appropriate for common lossless formats
+                } else if (video_c.codec_id() == AV_CODEC_ID_JPEGLS) {
+                    video_c.pix_fmt(AV_PIX_FMT_BGR24);
+                } else if (video_c.codec_id() == AV_CODEC_ID_MJPEG || video_c.codec_id() == AV_CODEC_ID_MJPEGB) {
+                    video_c.pix_fmt(AV_PIX_FMT_YUVJ420P);
+                } else {
+                    video_c.pix_fmt(AV_PIX_FMT_YUV420P); // lossy, but works with about everything
+                }
 
-            if (video_c.codec_id() == AV_CODEC_ID_MPEG2VIDEO) {
-                /* just for testing, we also add B frames */
-                video_c.max_b_frames(2);
-            } else if (video_c.codec_id() == AV_CODEC_ID_MPEG1VIDEO) {
+                if (video_c.codec_id() == AV_CODEC_ID_MPEG2VIDEO) {
+                    /* just for testing, we also add B frames */
+                    video_c.max_b_frames(2);
+                } else if (video_c.codec_id() == AV_CODEC_ID_MPEG1VIDEO) {
                 /* Needed to avoid using macroblocks in which some coeffs overflow.
                    This does not happen with normal video, it just happens here as
                    the motion of the chroma plane does not match the luma plane. */
-                video_c.mb_decision(2);
-            } else if (video_c.codec_id() == AV_CODEC_ID_H263) {
-                // H.263 does not support any other resolution than the following
-                if (imageWidth <= 128 && imageHeight <= 96) {
-                    video_c.width(128).height(96);
-                } else if (imageWidth <= 176 && imageHeight <= 144) {
-                    video_c.width(176).height(144);
-                } else if (imageWidth <= 352 && imageHeight <= 288) {
-                    video_c.width(352).height(288);
-                } else if (imageWidth <= 704 && imageHeight <= 576) {
-                    video_c.width(704).height(576);
-                } else {
-                    video_c.width(1408).height(1152);
+                    video_c.mb_decision(2);
+                } else if (video_c.codec_id() == AV_CODEC_ID_H263) {
+                    // H.263 does not support any other resolution than the following
+                    if (imageWidth <= 128 && imageHeight <= 96) {
+                        video_c.width(128).height(96);
+                    } else if (imageWidth <= 176 && imageHeight <= 144) {
+                        video_c.width(176).height(144);
+                    } else if (imageWidth <= 352 && imageHeight <= 288) {
+                        video_c.width(352).height(288);
+                    } else if (imageWidth <= 704 && imageHeight <= 576) {
+                        video_c.width(704).height(576);
+                    } else {
+                        video_c.width(1408).height(1152);
+                    }
+                } else if (video_c.codec_id() == AV_CODEC_ID_H264) {
+                    // default to constrained baseline to produce content that plays back on anything,
+                    // without any significant tradeoffs for most use cases
+                    video_c.profile(AVCodecContext.FF_PROFILE_H264_CONSTRAINED_BASELINE);
                 }
-            } else if (video_c.codec_id() == AV_CODEC_ID_H264) {
-                // default to constrained baseline to produce content that plays back on anything,
-                // without any significant tradeoffs for most use cases
-                video_c.profile(AVCodecContext.FF_PROFILE_H264_CONSTRAINED_BASELINE);
+
+                // some formats want stream headers to be separate
+                if ((oformat.flags() & AVFMT_GLOBALHEADER) != 0) {
+                    video_c.flags(video_c.flags() | AV_CODEC_FLAG_GLOBAL_HEADER);
+                }
+
+                if ((video_codec.capabilities() & AV_CODEC_CAP_EXPERIMENTAL) != 0) {
+                    video_c.strict_std_compliance(AVCodecContext.FF_COMPLIANCE_EXPERIMENTAL);
+                }
+
+                if (maxBFrames >= 0) {
+                    video_c.max_b_frames(maxBFrames);
+                    video_c.has_b_frames(maxBFrames == 0 ? 0 : 1);
+                }
+
+                if (trellis >= 0) {
+                    video_c.trellis(trellis);
+                }
             }
 
-            // some formats want stream headers to be separate
-            if ((oformat.flags() & AVFMT_GLOBALHEADER) != 0) {
-                video_c.flags(video_c.flags() | AV_CODEC_FLAG_GLOBAL_HEADER);
-            }
-
-            if ((video_codec.capabilities() & AV_CODEC_CAP_EXPERIMENTAL) != 0) {
-                video_c.strict_std_compliance(AVCodecContext.FF_COMPLIANCE_EXPERIMENTAL);
-            }
-
-            if (maxBFrames >= 0) {
-                video_c.max_b_frames(maxBFrames);
-                video_c.has_b_frames(maxBFrames == 0 ? 0 : 1);
-            }
-
-            if (trellis >= 0) {
-                video_c.trellis(trellis);
-            }
-        }
-
-        /*
-         * add an audio output stream
-         */
-        if (audioChannels > 0 && audioBitrate > 0 && sampleRate > 0) {
-            if (audioCodec == AV_CODEC_ID_NONE) {
-                audioCodec = oformat.audio_codec();
-            }
+            /*
+             * add an audio output stream
+             */
+            if (audioChannels > 0 && audioBitrate > 0 && sampleRate > 0) {
+                if (audioCodec == AV_CODEC_ID_NONE) {
+                    audioCodec = oformat.audio_codec();
+                }
 //            if (audioCodec != AV_CODEC_ID_NONE) {
 //                oformat.audio_codec(audioCodec);
 //            } else if ("flv".equals(format_name) || "mp4".equals(format_name) || "3gp".equals(format_name)) {
@@ -665,120 +716,131 @@ public class FFmpegFrameRecorder extends FrameRecorder {
 //                oformat.audio_codec(AV_CODEC_ID_PCM_S16LE);
 //            }
 
-            /* find the audio encoder */
-            if ((audio_codec = avcodec_find_encoder_by_name(audioCodecName)) == null &&
-                (audio_codec = avcodec_find_encoder(audioCodec)) == null) {
-                releaseUnsafe();
-                throw new Exception("avcodec_find_encoder() error: Audio codec not found.");
-            }
+                /* find the audio encoder */
+                if ((audio_codec = avcodec_find_encoder_by_name(audioCodecName)) == null &&
+                        (audio_codec = avcodec_find_encoder(audioCodec)) == null) {
+                    releaseUnsafe();
+                    throw new Exception("avcodec_find_encoder() error: Audio codec not found.");
+                }
 //            oformat.audio_codec(audio_codec.id());
 
-            AVRational sample_rate = av_d2q(sampleRate, 1001000);
+                AVRational sample_rate = av_d2q(sampleRate, 1001000);
 
-            if ((audio_st = avformat_new_stream(oc, null)) == null) {
-                releaseUnsafe();
-                throw new Exception("avformat_new_stream() error: Could not allocate audio stream.");
-            }
-
-            if ((audio_c = avcodec_alloc_context3(audio_codec)) == null) {
-                releaseUnsafe();
-                throw new Exception("avcodec_alloc_context3() error: Could not allocate audio encoding context.");
-            }
-
-            if (inpAudioStream != null && audioChannels > 0) {
-                if ((ret = avcodec_parameters_copy(audio_st.codecpar(), inpAudioStream.codecpar())) < 0) {
-                    throw new Exception("avcodec_parameters_copy() error " + ret + ": Failed to copy audio stream codec parameters from input to output");
+                if ((audio_st = avformat_new_stream(oc, null)) == null) {
+                    releaseUnsafe();
+                    throw new Exception("avformat_new_stream() error: Could not allocate audio stream.");
                 }
 
-                audioBitrate = (int) inpAudioStream.codecpar().bit_rate();
-                sampleRate = inpAudioStream.codecpar().sample_rate();
-                audioChannels = inpAudioStream.codecpar().channels();
-                sampleFormat = inpAudioStream.codecpar().format();
+                if ((audio_c = avcodec_alloc_context3(audio_codec)) == null) {
+                    releaseUnsafe();
+                    throw new Exception("avcodec_alloc_context3() error: Could not allocate audio encoding context.");
+                }
+
+                if (inpAudioStream != null && audioChannels > 0) {
+                    if ((ret = avcodec_parameters_copy(audio_st.codecpar(), inpAudioStream.codecpar())) < 0) {
+                        throw new Exception("avcodec_parameters_copy() error " + ret + ": Failed to copy audio stream codec parameters from input to output");
+                    }
+
+                    audioBitrate = (int) inpAudioStream.codecpar().bit_rate();
+                    sampleRate = inpAudioStream.codecpar().sample_rate();
+                    audioChannels = inpAudioStream.codecpar().channels();
+                    sampleFormat = inpAudioStream.codecpar().format();
 //                audioQuality = inpAudioStream.codecpar().global_quality();
-                audio_c.codec_tag(0);
+                    audio_c.codec_tag(0);
 //                audio_st.pts(inpAudioStream.pts());
-                audio_st.duration(inpAudioStream.duration());
-                audio_st.time_base().num(inpAudioStream.time_base().num());
-                audio_st.time_base().den(inpAudioStream.time_base().den());
-            }
+                    audio_st.duration(inpAudioStream.duration());
+                    audio_st.time_base().num(inpAudioStream.time_base().num());
+                    audio_st.time_base().den(inpAudioStream.time_base().den());
+                }
 
-            audio_c.codec_id(audio_codec.id());
-            audio_c.codec_type(AVMEDIA_TYPE_AUDIO);
+                audio_c.codec_id(audio_codec.id());
+                audio_c.codec_type(AVMEDIA_TYPE_AUDIO);
 
 
-            /* put sample parameters */
-            audio_c.bit_rate(audioBitrate);
-            audio_c.sample_rate(sampleRate);
-            audio_c.channels(audioChannels);
-            audio_c.channel_layout(av_get_default_channel_layout(audioChannels));
-            if (sampleFormat != AV_SAMPLE_FMT_NONE) {
-                audio_c.sample_fmt(sampleFormat);
-            } else {
-                // use AV_SAMPLE_FMT_S16 by default, if available
-                audio_c.sample_fmt(AV_SAMPLE_FMT_FLTP);
-                IntPointer formats = audio_c.codec().sample_fmts();
-                for (int i = 0; formats.get(i) != -1; i++) {
-                    if (formats.get(i) == AV_SAMPLE_FMT_S16) {
-                        audio_c.sample_fmt(AV_SAMPLE_FMT_S16);
-                        break;
+                /* put sample parameters */
+                audio_c.bit_rate(audioBitrate);
+                audio_c.sample_rate(sampleRate);
+                audio_c.channels(audioChannels);
+                audio_c.channel_layout(av_get_default_channel_layout(audioChannels));
+                if (sampleFormat != AV_SAMPLE_FMT_NONE) {
+                    audio_c.sample_fmt(sampleFormat);
+                } else {
+                    // use AV_SAMPLE_FMT_S16 by default, if available
+                    audio_c.sample_fmt(AV_SAMPLE_FMT_FLTP);
+                    IntPointer formats = audio_c.codec().sample_fmts();
+                    for (int i = 0; formats.get(i) != -1; i++) {
+                        if (formats.get(i) == AV_SAMPLE_FMT_S16) {
+                            audio_c.sample_fmt(AV_SAMPLE_FMT_S16);
+                            break;
+                        }
                     }
                 }
-            }
-            AVRational time_base = av_inv_q(sample_rate);
-            audio_c.time_base(time_base);
-            audio_st.time_base(time_base);
+                AVRational time_base = av_inv_q(sample_rate);
+                audio_c.time_base(time_base);
+                audio_st.time_base(time_base);
 //            audio_st.codec().time_base(time_base); // "deprecated", but this is actually required
-            switch (audio_c.sample_fmt()) {
-                case AV_SAMPLE_FMT_U8:
-                case AV_SAMPLE_FMT_U8P:  audio_c.bits_per_raw_sample(8);  break;
-                case AV_SAMPLE_FMT_S16:
-                case AV_SAMPLE_FMT_S16P: audio_c.bits_per_raw_sample(16); break;
-                case AV_SAMPLE_FMT_S32:
-                case AV_SAMPLE_FMT_S32P: audio_c.bits_per_raw_sample(32); break;
-                case AV_SAMPLE_FMT_FLT:
-                case AV_SAMPLE_FMT_FLTP: audio_c.bits_per_raw_sample(32); break;
-                case AV_SAMPLE_FMT_DBL:
-                case AV_SAMPLE_FMT_DBLP: audio_c.bits_per_raw_sample(64); break;
-                default: assert false;
-            }
-            if (audioQuality >= 0) {
-                audio_c.flags(audio_c.flags() | AV_CODEC_FLAG_QSCALE);
-                audio_c.global_quality((int)Math.round(FF_QP2LAMBDA * audioQuality));
-            }
+                switch (audio_c.sample_fmt()) {
+                    case AV_SAMPLE_FMT_U8:
+                    case AV_SAMPLE_FMT_U8P:
+                        audio_c.bits_per_raw_sample(8);
+                        break;
+                    case AV_SAMPLE_FMT_S16:
+                    case AV_SAMPLE_FMT_S16P:
+                        audio_c.bits_per_raw_sample(16);
+                        break;
+                    case AV_SAMPLE_FMT_S32:
+                    case AV_SAMPLE_FMT_S32P:
+                        audio_c.bits_per_raw_sample(32);
+                        break;
+                    case AV_SAMPLE_FMT_FLT:
+                    case AV_SAMPLE_FMT_FLTP:
+                        audio_c.bits_per_raw_sample(32);
+                        break;
+                    case AV_SAMPLE_FMT_DBL:
+                    case AV_SAMPLE_FMT_DBLP:
+                        audio_c.bits_per_raw_sample(64);
+                        break;
+                    default:
+                        assert false;
+                }
+                if (audioQuality >= 0) {
+                    audio_c.flags(audio_c.flags() | AV_CODEC_FLAG_QSCALE);
+                    audio_c.global_quality((int) Math.round(FF_QP2LAMBDA * audioQuality));
+                }
 
-            // some formats want stream headers to be separate
-            if ((oformat.flags() & AVFMT_GLOBALHEADER) != 0) {
-                audio_c.flags(audio_c.flags() | AV_CODEC_FLAG_GLOBAL_HEADER);
-            }
+                // some formats want stream headers to be separate
+                if ((oformat.flags() & AVFMT_GLOBALHEADER) != 0) {
+                    audio_c.flags(audio_c.flags() | AV_CODEC_FLAG_GLOBAL_HEADER);
+                }
 
-            if ((audio_codec.capabilities() & AV_CODEC_CAP_EXPERIMENTAL) != 0) {
-                audio_c.strict_std_compliance(AVCodecContext.FF_COMPLIANCE_EXPERIMENTAL);
+                if ((audio_codec.capabilities() & AV_CODEC_CAP_EXPERIMENTAL) != 0) {
+                    audio_c.strict_std_compliance(AVCodecContext.FF_COMPLIANCE_EXPERIMENTAL);
+                }
             }
-        }
 
         /* now that all the parameters are set, we can open the audio and
            video codecs and allocate the necessary encode buffers */
-        if (video_st != null && inpVideoStream == null) {
-            AVDictionary options = new AVDictionary(null);
-            if (videoQuality >= 0) {
-                av_dict_set(options, "crf", "" + videoQuality, 0);
-            }
-            for (Entry<String, String> e : videoOptions.entrySet()) {
-                av_dict_set(options, e.getKey(), e.getValue(), 0);
-            }
+            if (video_st != null && inpVideoStream == null) {
+                AVDictionary options = new AVDictionary(null);
+                if (videoQuality >= 0) {
+                    av_dict_set(options, "crf", "" + videoQuality, 0);
+                }
+                for (Entry<String, String> e : videoOptions.entrySet()) {
+                    av_dict_set(options, e.getKey(), e.getValue(), 0);
+                }
 
-            // Enable multithreading when available
-            video_c.thread_count(0);
+                // Enable multithreading when available
+                video_c.thread_count(0);
 
-            /* open the codec */
-            if ((ret = avcodec_open2(video_c, video_codec, options)) < 0) {
-                releaseUnsafe();
+                /* open the codec */
+                if ((ret = avcodec_open2(video_c, video_codec, options)) < 0) {
+                    releaseUnsafe();
+                    av_dict_free(options);
+                    throw new Exception("avcodec_open2() error " + ret + ": Could not open video codec.");
+                }
                 av_dict_free(options);
-                throw new Exception("avcodec_open2() error " + ret + ": Could not open video codec.");
-            }
-            av_dict_free(options);
 
-            video_outbuf = null;
+                video_outbuf = null;
 //            if ((oformat.flags() & AVFMT_RAWPICTURE) == 0) {
 //                /* allocate output buffer */
 //                /* XXX: API change will be done */
@@ -790,145 +852,145 @@ public class FFmpegFrameRecorder extends FrameRecorder {
 //                video_outbuf = new BytePointer(av_malloc(video_outbuf_size));
 //            }
 
-            /* allocate the encoded raw picture */
-            if ((picture = av_frame_alloc()) == null) {
-                releaseUnsafe();
-                throw new Exception("av_frame_alloc() error: Could not allocate picture.");
-            }
-            picture.pts(0); // magic required by libx264
+                /* allocate the encoded raw picture */
+                if ((picture = av_frame_alloc()) == null) {
+                    releaseUnsafe();
+                    throw new Exception("av_frame_alloc() error: Could not allocate picture.");
+                }
+                picture.pts(0); // magic required by libx264
 
-            int size = av_image_get_buffer_size(video_c.pix_fmt(), video_c.width(), video_c.height(), 1);
-            if ((picture_buf = new BytePointer(av_malloc(size))).isNull()) {
-                releaseUnsafe();
-                throw new Exception("av_malloc() error: Could not allocate picture buffer.");
-            }
+                int size = av_image_get_buffer_size(video_c.pix_fmt(), video_c.width(), video_c.height(), 1);
+                if ((picture_buf = new BytePointer(av_malloc(size))).isNull()) {
+                    releaseUnsafe();
+                    throw new Exception("av_malloc() error: Could not allocate picture buffer.");
+                }
 
             /* if the output format is not equal to the image format, then a temporary
                picture is needed too. It is then converted to the required output format */
-            if ((tmp_picture = av_frame_alloc()) == null) {
-                releaseUnsafe();
-                throw new Exception("av_frame_alloc() error: Could not allocate temporary picture.");
+                if ((tmp_picture = av_frame_alloc()) == null) {
+                    releaseUnsafe();
+                    throw new Exception("av_frame_alloc() error: Could not allocate temporary picture.");
+                }
+
+                /* copy the stream parameters to the muxer */
+                if ((ret = avcodec_parameters_from_context(video_st.codecpar(), video_c)) < 0) {
+                    releaseUnsafe();
+                    throw new Exception("avcodec_parameters_from_context() error " + ret + ": Could not copy the video stream parameters.");
+                }
+
+                AVDictionary metadata = new AVDictionary(null);
+                for (Entry<String, String> e : videoMetadata.entrySet()) {
+                    av_dict_set(metadata, new BytePointer(e.getKey(), charset), new BytePointer(e.getValue(), charset), 0);
+                }
+                video_st.metadata(metadata);
             }
 
-            /* copy the stream parameters to the muxer */
-            if ((ret = avcodec_parameters_from_context(video_st.codecpar(), video_c)) < 0) {
-                releaseUnsafe();
-                throw new Exception("avcodec_parameters_from_context() error " + ret + ": Could not copy the video stream parameters.");
-            }
+            if (audio_st != null && inpAudioStream == null) {
+                AVDictionary options = new AVDictionary(null);
+                if (audioQuality >= 0) {
+                    av_dict_set(options, "crf", "" + audioQuality, 0);
+                }
+                for (Entry<String, String> e : audioOptions.entrySet()) {
+                    av_dict_set(options, e.getKey(), e.getValue(), 0);
+                }
 
-            AVDictionary metadata = new AVDictionary(null);
-            for (Entry<String, String> e : videoMetadata.entrySet()) {
-                av_dict_set(metadata, new BytePointer(e.getKey(), charset), new BytePointer(e.getValue(), charset), 0);
-            }
-            video_st.metadata(metadata);
-        }
+                // Enable multithreading when available
+                audio_c.thread_count(0);
 
-        if (audio_st != null && inpAudioStream == null) {
-            AVDictionary options = new AVDictionary(null);
-            if (audioQuality >= 0) {
-                av_dict_set(options, "crf", "" + audioQuality, 0);
-            }
-            for (Entry<String, String> e : audioOptions.entrySet()) {
-                av_dict_set(options, e.getKey(), e.getValue(), 0);
-            }
-
-            // Enable multithreading when available
-            audio_c.thread_count(0);
-
-            /* open the codec */
-            if ((ret = avcodec_open2(audio_c, audio_codec, options)) < 0) {
-                releaseUnsafe();
+                /* open the codec */
+                if ((ret = avcodec_open2(audio_c, audio_codec, options)) < 0) {
+                    releaseUnsafe();
+                    av_dict_free(options);
+                    throw new Exception("avcodec_open2() error " + ret + ": Could not open audio codec.");
+                }
                 av_dict_free(options);
-                throw new Exception("avcodec_open2() error " + ret + ": Could not open audio codec.");
-            }
-            av_dict_free(options);
 
-            audio_outbuf_size = 256 * 1024;
-            audio_outbuf = new BytePointer(av_malloc(audio_outbuf_size));
+                audio_outbuf_size = 256 * 1024;
+                audio_outbuf = new BytePointer(av_malloc(audio_outbuf_size));
 
             /* ugly hack for PCM codecs (will be removed ASAP with new PCM
                support to compute the input frame size in samples */
-            if (audio_c.frame_size() <= 1) {
-                audio_outbuf_size = AV_INPUT_BUFFER_MIN_SIZE;
-                audio_input_frame_size = audio_outbuf_size / audio_c.channels();
-                switch (audio_c.codec_id()) {
-                    case AV_CODEC_ID_PCM_S16LE:
-                    case AV_CODEC_ID_PCM_S16BE:
-                    case AV_CODEC_ID_PCM_U16LE:
-                    case AV_CODEC_ID_PCM_U16BE:
-                        audio_input_frame_size >>= 1;
-                        break;
-                    default:
-                        break;
+                if (audio_c.frame_size() <= 1) {
+                    audio_outbuf_size = AV_INPUT_BUFFER_MIN_SIZE;
+                    audio_input_frame_size = audio_outbuf_size / audio_c.channels();
+                    switch (audio_c.codec_id()) {
+                        case AV_CODEC_ID_PCM_S16LE:
+                        case AV_CODEC_ID_PCM_S16BE:
+                        case AV_CODEC_ID_PCM_U16LE:
+                        case AV_CODEC_ID_PCM_U16BE:
+                            audio_input_frame_size >>= 1;
+                            break;
+                        default:
+                            break;
+                    }
+                } else {
+                    audio_input_frame_size = audio_c.frame_size();
                 }
-            } else {
-                audio_input_frame_size = audio_c.frame_size();
-            }
-            //int bufferSize = audio_input_frame_size * audio_c.bits_per_raw_sample()/8 * audio_c.channels();
-            int planes = av_sample_fmt_is_planar(audio_c.sample_fmt()) != 0 ? (int)audio_c.channels() : 1;
-            int data_size = av_samples_get_buffer_size((IntPointer)null, audio_c.channels(),
-                    audio_input_frame_size, audio_c.sample_fmt(), 1) / planes;
-            samples_out = new BytePointer[planes];
-            for (int i = 0; i < samples_out.length; i++) {
-                samples_out[i] = new BytePointer(av_malloc(data_size)).capacity(data_size);
-            }
-            samples_in = new Pointer[AVFrame.AV_NUM_DATA_POINTERS];
+                //int bufferSize = audio_input_frame_size * audio_c.bits_per_raw_sample()/8 * audio_c.channels();
+                int planes = av_sample_fmt_is_planar(audio_c.sample_fmt()) != 0 ? (int) audio_c.channels() : 1;
+                int data_size = av_samples_get_buffer_size((IntPointer) null, audio_c.channels(),
+                        audio_input_frame_size, audio_c.sample_fmt(), 1) / planes;
+                samples_out = new BytePointer[planes];
+                for (int i = 0; i < samples_out.length; i++) {
+                    samples_out[i] = new BytePointer(av_malloc(data_size)).capacity(data_size);
+                }
+                samples_in = new Pointer[AVFrame.AV_NUM_DATA_POINTERS];
 
-            /* allocate the audio frame */
-            if ((frame = av_frame_alloc()) == null) {
-                releaseUnsafe();
-                throw new Exception("av_frame_alloc() error: Could not allocate audio frame.");
-            }
-            frame.pts(0); // magic required by libvorbis and webm
+                /* allocate the audio frame */
+                if ((frame = av_frame_alloc()) == null) {
+                    releaseUnsafe();
+                    throw new Exception("av_frame_alloc() error: Could not allocate audio frame.");
+                }
+                frame.pts(0); // magic required by libvorbis and webm
 
-            /* copy the stream parameters to the muxer */
-            if ((ret = avcodec_parameters_from_context(audio_st.codecpar(), audio_c)) < 0) {
-                releaseUnsafe();
-                throw new Exception("avcodec_parameters_from_context() error " + ret + ": Could not copy the audio stream parameters.");
+                /* copy the stream parameters to the muxer */
+                if ((ret = avcodec_parameters_from_context(audio_st.codecpar(), audio_c)) < 0) {
+                    releaseUnsafe();
+                    throw new Exception("avcodec_parameters_from_context() error " + ret + ": Could not copy the audio stream parameters.");
+                }
+
+                AVDictionary metadata = new AVDictionary(null);
+                for (Entry<String, String> e : audioMetadata.entrySet()) {
+                    av_dict_set(metadata, new BytePointer(e.getKey(), charset), new BytePointer(e.getValue(), charset), 0);
+                }
+                audio_st.metadata(metadata);
+            }
+
+            AVDictionary options = new AVDictionary(null);
+            for (Entry<String, String> e : this.options.entrySet()) {
+                av_dict_set(options, e.getKey(), e.getValue(), 0);
+            }
+
+            /* open the output file, if needed */
+            if (outputStream == null && (oformat.flags() & AVFMT_NOFILE) == 0) {
+                AVIOContext pb = new AVIOContext(null);
+                if ((ret = avio_open2(pb, filename, AVIO_FLAG_WRITE, null, options)) < 0) {
+                    String errorMsg = "avio_open2 error() error " + ret + ": Could not open '" + filename + "'";
+                    releaseUnsafe();
+                    av_dict_free(options);
+                    throw new Exception(errorMsg);
+                }
+                oc.pb(pb);
             }
 
             AVDictionary metadata = new AVDictionary(null);
-            for (Entry<String, String> e : audioMetadata.entrySet()) {
+            for (Entry<String, String> e : this.metadata.entrySet()) {
                 av_dict_set(metadata, new BytePointer(e.getKey(), charset), new BytePointer(e.getValue(), charset), 0);
             }
-            audio_st.metadata(metadata);
-        }
-
-        AVDictionary options = new AVDictionary(null);
-        for (Entry<String, String> e : this.options.entrySet()) {
-            av_dict_set(options, e.getKey(), e.getValue(), 0);
-        }
-
-        /* open the output file, if needed */
-        if (outputStream == null && (oformat.flags() & AVFMT_NOFILE) == 0) {
-            AVIOContext pb = new AVIOContext(null);
-            if ((ret = avio_open2(pb, filename, AVIO_FLAG_WRITE, null, options)) < 0) {
-                String errorMsg = "avio_open2 error() error " + ret + ": Could not open '" + filename + "'";
+            /* write the stream header, if any */
+            if ((ret = avformat_write_header(oc.metadata(metadata), options)) < 0) {
+                String errorMsg = "avformat_write_header error() error " + ret + ": Could not write header to '" + filename + "'";
                 releaseUnsafe();
                 av_dict_free(options);
                 throw new Exception(errorMsg);
             }
-            oc.pb(pb);
-        }
-
-        AVDictionary metadata = new AVDictionary(null);
-        for (Entry<String, String> e : this.metadata.entrySet()) {
-            av_dict_set(metadata, new BytePointer(e.getKey(), charset), new BytePointer(e.getValue(), charset), 0);
-        }
-        /* write the stream header, if any */
-        if ((ret = avformat_write_header(oc.metadata(metadata), options)) < 0) {
-            String errorMsg = "avformat_write_header error() error " + ret + ": Could not write header to '" + filename + "'";
-            releaseUnsafe();
             av_dict_free(options);
-            throw new Exception(errorMsg);
-        }
-        av_dict_free(options);
 
-        if (av_log_get_level() >= AV_LOG_INFO) {
-            av_dump_format(oc, 0, filename, 1);
-        }
+            if (av_log_get_level() >= AV_LOG_INFO) {
+                av_dump_format(oc, 0, filename, 1);
+            }
 
-        started = true;
+            started = true;
 
         }
     }
@@ -936,8 +998,9 @@ public class FFmpegFrameRecorder extends FrameRecorder {
     public synchronized void flush() throws Exception {
         synchronized (oc) {
             /* flush all the buffers */
-            while (video_st != null && ifmt_ctx == null && recordImage(0, 0, 0, 0, 0, AV_PIX_FMT_NONE, (Buffer[])null));
-            while (audio_st != null && ifmt_ctx == null && recordSamples(0, 0, (Buffer[])null));
+            while (video_st != null && ifmt_ctx == null && recordImage(0, 0, 0, 0, 0, AV_PIX_FMT_NONE, (Buffer[]) null))
+                ;
+            while (audio_st != null && ifmt_ctx == null && recordSamples(0, 0, (Buffer[]) null)) ;
 
             if (interleaved && (video_st != null || audio_st != null)) {
                 av_interleaved_write_frame(oc, null);
@@ -960,12 +1023,14 @@ public class FFmpegFrameRecorder extends FrameRecorder {
         }
     }
 
-    @Override public void record(Frame frame) throws Exception {
-        record(frame, frame != null && frame.opaque instanceof AVFrame ? ((AVFrame)frame.opaque).format() : AV_PIX_FMT_NONE);
+    @Override
+    public void record(Frame frame) throws Exception {
+        record(frame, frame != null && frame.opaque instanceof AVFrame ? ((AVFrame) frame.opaque).format() : AV_PIX_FMT_NONE);
     }
+
     public synchronized void record(Frame frame, int pixelFormat) throws Exception {
         if (frame == null || (frame.image == null && frame.samples == null && frame.data == null)) {
-            recordImage(0, 0, 0, 0, 0, pixelFormat, (Buffer[])null);
+            recordImage(0, 0, 0, 0, 0, pixelFormat, (Buffer[]) null);
         } else {
             if (frame.image != null) {
                 frame.keyFrame = recordImage(frame.imageWidth, frame.imageHeight, frame.imageDepth,
@@ -977,76 +1042,76 @@ public class FFmpegFrameRecorder extends FrameRecorder {
         }
     }
 
-    public synchronized boolean recordImage(int width, int height, int depth, int channels, int stride, int pixelFormat, Buffer ... image) throws Exception {
+    public synchronized boolean recordImage(int width, int height, int depth, int channels, int stride, int pixelFormat, Buffer... image) throws Exception {
         try (PointerScope scope = new PointerScope()) {
 
-        if (video_st == null) {
-            throw new Exception("No video output stream (Is imageWidth > 0 && imageHeight > 0 and has start() been called?)");
-        }
-        if (!started) {
-            throw new Exception("start() was not called successfully!");
-        }
-        int ret;
+            if (video_st == null) {
+                throw new Exception("No video output stream (Is imageWidth > 0 && imageHeight > 0 and has start() been called?)");
+            }
+            if (!started) {
+                throw new Exception("start() was not called successfully!");
+            }
+            int ret;
 
-        if (image == null || image.length == 0) {
+            if (image == null || image.length == 0) {
             /* no more frame to compress. The codec has a latency of a few
                frames if using B frames, so we get the last frames by
                passing the same picture again */
-        } else {
-            int step = stride * Math.abs(depth) / 8;
-            BytePointer data = image[0] instanceof ByteBuffer
-                    ? new BytePointer((ByteBuffer)image[0]).position(0)
-                    : new BytePointer(new Pointer(image[0]).position(0));
-
-            if (pixelFormat == AV_PIX_FMT_NONE) {
-                if ((depth == Frame.DEPTH_UBYTE || depth == Frame.DEPTH_BYTE) && channels == 3) {
-                    pixelFormat = AV_PIX_FMT_BGR24;
-                } else if ((depth == Frame.DEPTH_UBYTE || depth == Frame.DEPTH_BYTE) && channels == 1) {
-                    pixelFormat = AV_PIX_FMT_GRAY8;
-                } else if ((depth == Frame.DEPTH_USHORT || depth == Frame.DEPTH_SHORT) && channels == 1) {
-                    pixelFormat = ByteOrder.nativeOrder().equals(ByteOrder.BIG_ENDIAN) ?
-                            AV_PIX_FMT_GRAY16BE : AV_PIX_FMT_GRAY16LE;
-                } else if ((depth == Frame.DEPTH_UBYTE || depth == Frame.DEPTH_BYTE) && channels == 4) {
-                    pixelFormat = AV_PIX_FMT_RGBA;
-                } else if ((depth == Frame.DEPTH_UBYTE || depth == Frame.DEPTH_BYTE) && channels == 2) {
-                    pixelFormat = AV_PIX_FMT_NV21; // Android's camera capture format
-                } else {
-                    throw new Exception("Could not guess pixel format of image: depth=" + depth + ", channels=" + channels);
-                }
-            }
-
-            if (pixelFormat == AV_PIX_FMT_NV21) {
-                step = width;
-            }
-
-            if (video_c.pix_fmt() != pixelFormat || video_c.width() != width || video_c.height() != height) {
-                /* convert to the codec pixel format if needed */
-                img_convert_ctx = sws_getCachedContext(img_convert_ctx, width, height, pixelFormat,
-                        video_c.width(), video_c.height(), video_c.pix_fmt(),
-                        imageScalingFlags != 0 ? imageScalingFlags : SWS_BILINEAR,
-                        null, null, (DoublePointer)null);
-                if (img_convert_ctx == null) {
-                    throw new Exception("sws_getCachedContext() error: Cannot initialize the conversion context.");
-                }
-                av_image_fill_arrays(new PointerPointer(tmp_picture), tmp_picture.linesize(), data, pixelFormat, width, height, 1);
-                av_image_fill_arrays(new PointerPointer(picture), picture.linesize(), picture_buf, video_c.pix_fmt(), video_c.width(), video_c.height(), 1);
-                tmp_picture.linesize(0, step);
-                tmp_picture.format(pixelFormat);
-                tmp_picture.width(width);
-                tmp_picture.height(height);
-                picture.format(video_c.pix_fmt());
-                picture.width(video_c.width());
-                picture.height(video_c.height());
-                sws_scale(img_convert_ctx, new PointerPointer(tmp_picture), tmp_picture.linesize(),
-                          0, height, new PointerPointer(picture), picture.linesize());
             } else {
-                av_image_fill_arrays(new PointerPointer(picture), picture.linesize(), data, pixelFormat, width, height, 1);
-                picture.linesize(0, step);
-                picture.format(pixelFormat);
-                picture.width(width);
-                picture.height(height);
+                int step = stride * Math.abs(depth) / 8;
+                BytePointer data = image[0] instanceof ByteBuffer
+                        ? new BytePointer((ByteBuffer) image[0]).position(0)
+                        : new BytePointer(new Pointer(image[0]).position(0));
+
+                if (pixelFormat == AV_PIX_FMT_NONE) {
+                    if ((depth == Frame.DEPTH_UBYTE || depth == Frame.DEPTH_BYTE) && channels == 3) {
+                        pixelFormat = AV_PIX_FMT_BGR24;
+                    } else if ((depth == Frame.DEPTH_UBYTE || depth == Frame.DEPTH_BYTE) && channels == 1) {
+                        pixelFormat = AV_PIX_FMT_GRAY8;
+                    } else if ((depth == Frame.DEPTH_USHORT || depth == Frame.DEPTH_SHORT) && channels == 1) {
+                        pixelFormat = ByteOrder.nativeOrder().equals(ByteOrder.BIG_ENDIAN) ?
+                                AV_PIX_FMT_GRAY16BE : AV_PIX_FMT_GRAY16LE;
+                    } else if ((depth == Frame.DEPTH_UBYTE || depth == Frame.DEPTH_BYTE) && channels == 4) {
+                        pixelFormat = AV_PIX_FMT_RGBA;
+                    } else if ((depth == Frame.DEPTH_UBYTE || depth == Frame.DEPTH_BYTE) && channels == 2) {
+                        pixelFormat = AV_PIX_FMT_NV21; // Android's camera capture format
+                    } else {
+                        throw new Exception("Could not guess pixel format of image: depth=" + depth + ", channels=" + channels);
+                    }
+                }
+
+                if (pixelFormat == AV_PIX_FMT_NV21) {
+                    step = width;
+                }
+
+                if (video_c.pix_fmt() != pixelFormat || video_c.width() != width || video_c.height() != height) {
+                    /* convert to the codec pixel format if needed */
+                    img_convert_ctx = sws_getCachedContext(img_convert_ctx, width, height, pixelFormat,
+                            video_c.width(), video_c.height(), video_c.pix_fmt(),
+                            imageScalingFlags != 0 ? imageScalingFlags : SWS_BILINEAR,
+                            null, null, (DoublePointer) null);
+                    if (img_convert_ctx == null) {
+                        throw new Exception("sws_getCachedContext() error: Cannot initialize the conversion context.");
+                    }
+                    av_image_fill_arrays(new PointerPointer(tmp_picture), tmp_picture.linesize(), data, pixelFormat, width, height, 1);
+                    av_image_fill_arrays(new PointerPointer(picture), picture.linesize(), picture_buf, video_c.pix_fmt(), video_c.width(), video_c.height(), 1);
+                    tmp_picture.linesize(0, step);
+                    tmp_picture.format(pixelFormat);
+                    tmp_picture.width(width);
+                    tmp_picture.height(height);
+                    picture.format(video_c.pix_fmt());
+                    picture.width(video_c.width());
+                    picture.height(video_c.height());
+                    sws_scale(img_convert_ctx, new PointerPointer(tmp_picture), tmp_picture.linesize(),
+                            0, height, new PointerPointer(picture), picture.linesize());
+                } else {
+                    av_image_fill_arrays(new PointerPointer(picture), picture.linesize(), data, pixelFormat, width, height, 1);
+                    picture.linesize(0, step);
+                    picture.format(pixelFormat);
+                    picture.width(width);
+                    picture.height(height);
+                }
             }
-        }
 
 //        if ((oformat.flags() & AVFMT_RAWPICTURE) != 0) {
 //            if (image == null || image.length == 0) {
@@ -1090,167 +1155,168 @@ public class FFmpegFrameRecorder extends FrameRecorder {
                 video_pkt.stream_index(video_st.index());
 
                 /* write the compressed frame in the media file */
-                writePacket(AVMEDIA_TYPE_VIDEO, video_pkt);
+                packetEncoded(AVMEDIA_TYPE_VIDEO, video_pkt);
             }
 //        }
-        return image != null ? (video_pkt.flags() & AV_PKT_FLAG_KEY) != 0 : got_video_packet[0] != 0;
+            return image != null ? (video_pkt.flags() & AV_PKT_FLAG_KEY) != 0 : got_video_packet[0] != 0;
 
         }
     }
 
-    public boolean recordSamples(Buffer ... samples) throws Exception {
+    public boolean recordSamples(Buffer... samples) throws Exception {
         return recordSamples(0, 0, samples);
     }
-    public synchronized boolean recordSamples(int sampleRate, int audioChannels, Buffer ... samples) throws Exception {
+
+    public synchronized boolean recordSamples(int sampleRate, int audioChannels, Buffer... samples) throws Exception {
         try (PointerScope scope = new PointerScope()) {
 
-        if (audio_st == null) {
-            throw new Exception("No audio output stream (Is audioChannels > 0 and has start() been called?)");
-        }
-        if (!started) {
-            throw new Exception("start() was not called successfully!");
-        }
+            if (audio_st == null) {
+                throw new Exception("No audio output stream (Is audioChannels > 0 and has start() been called?)");
+            }
+            if (!started) {
+                throw new Exception("start() was not called successfully!");
+            }
 
-        if (samples == null && samples_out[0].position() > 0) {
-            // Typically samples_out[0].limit() is double the audio_input_frame_size --> sampleDivisor = 2
-            double sampleDivisor = Math.floor((int)Math.min(samples_out[0].limit(), Integer.MAX_VALUE) / audio_input_frame_size);
-            writeSamples((int)Math.floor((int)samples_out[0].position() / sampleDivisor));
-            return writeFrame((AVFrame)null);
-        }
+            if (samples == null && samples_out[0].position() > 0) {
+                // Typically samples_out[0].limit() is double the audio_input_frame_size --> sampleDivisor = 2
+                double sampleDivisor = Math.floor((int) Math.min(samples_out[0].limit(), Integer.MAX_VALUE) / audio_input_frame_size);
+                writeSamples((int) Math.floor((int) samples_out[0].position() / sampleDivisor));
+                return writeFrame((AVFrame) null);
+            }
 
-        int ret;
+            int ret;
 
-        if (sampleRate <= 0) {
-            sampleRate = audio_c.sample_rate();
-        }
-        if (audioChannels <= 0) {
-            audioChannels = audio_c.channels();
-        }
-        int inputSize = samples != null ? samples[0].limit() - samples[0].position() : 0;
-        int inputFormat = samples_format;
-        int inputChannels = samples != null && samples.length > 1 ? 1 : audioChannels;
-        int inputDepth = 0;
-        int outputFormat = audio_c.sample_fmt();
-        int outputChannels = samples_out.length > 1 ? 1 : audio_c.channels();
-        int outputDepth = av_get_bytes_per_sample(outputFormat);
-        if (samples != null && samples[0] instanceof ByteBuffer) {
-            inputFormat = samples.length > 1 ? AV_SAMPLE_FMT_U8P : AV_SAMPLE_FMT_U8;
-            inputDepth = 1;
-            for (int i = 0; i < samples.length; i++) {
-                ByteBuffer b = (ByteBuffer)samples[i];
-                if (samples_in[i] instanceof BytePointer && samples_in[i].capacity() >= inputSize && b.hasArray()) {
-                    ((BytePointer)samples_in[i]).position(0).put(b.array(), b.position(), inputSize);
-                } else {
-                    if (samples_in[i] != null) {
-                        samples_in[i].releaseReference();
-                    }
-                    samples_in[i] = new BytePointer(b).retainReference();
-                }
+            if (sampleRate <= 0) {
+                sampleRate = audio_c.sample_rate();
             }
-        } else if (samples != null && samples[0] instanceof ShortBuffer) {
-            inputFormat = samples.length > 1 ? AV_SAMPLE_FMT_S16P : AV_SAMPLE_FMT_S16;
-            inputDepth = 2;
-            for (int i = 0; i < samples.length; i++) {
-                ShortBuffer b = (ShortBuffer)samples[i];
-                if (samples_in[i] instanceof ShortPointer && samples_in[i].capacity() >= inputSize && b.hasArray()) {
-                    ((ShortPointer)samples_in[i]).position(0).put(b.array(), samples[i].position(), inputSize);
-                } else {
-                    if (samples_in[i] != null) {
-                        samples_in[i].releaseReference();
-                    }
-                    samples_in[i] = new ShortPointer(b).retainReference();
-                }
+            if (audioChannels <= 0) {
+                audioChannels = audio_c.channels();
             }
-        } else if (samples != null && samples[0] instanceof IntBuffer) {
-            inputFormat = samples.length > 1 ? AV_SAMPLE_FMT_S32P : AV_SAMPLE_FMT_S32;
-            inputDepth = 4;
-            for (int i = 0; i < samples.length; i++) {
-                IntBuffer b = (IntBuffer)samples[i];
-                if (samples_in[i] instanceof IntPointer && samples_in[i].capacity() >= inputSize && b.hasArray()) {
-                    ((IntPointer)samples_in[i]).position(0).put(b.array(), samples[i].position(), inputSize);
-                } else {
-                    if (samples_in[i] != null) {
-                        samples_in[i].releaseReference();
+            int inputSize = samples != null ? samples[0].limit() - samples[0].position() : 0;
+            int inputFormat = samples_format;
+            int inputChannels = samples != null && samples.length > 1 ? 1 : audioChannels;
+            int inputDepth = 0;
+            int outputFormat = audio_c.sample_fmt();
+            int outputChannels = samples_out.length > 1 ? 1 : audio_c.channels();
+            int outputDepth = av_get_bytes_per_sample(outputFormat);
+            if (samples != null && samples[0] instanceof ByteBuffer) {
+                inputFormat = samples.length > 1 ? AV_SAMPLE_FMT_U8P : AV_SAMPLE_FMT_U8;
+                inputDepth = 1;
+                for (int i = 0; i < samples.length; i++) {
+                    ByteBuffer b = (ByteBuffer) samples[i];
+                    if (samples_in[i] instanceof BytePointer && samples_in[i].capacity() >= inputSize && b.hasArray()) {
+                        ((BytePointer) samples_in[i]).position(0).put(b.array(), b.position(), inputSize);
+                    } else {
+                        if (samples_in[i] != null) {
+                            samples_in[i].releaseReference();
+                        }
+                        samples_in[i] = new BytePointer(b).retainReference();
                     }
-                    samples_in[i] = new IntPointer(b).retainReference();
                 }
-            }
-        } else if (samples != null && samples[0] instanceof FloatBuffer) {
-            inputFormat = samples.length > 1 ? AV_SAMPLE_FMT_FLTP : AV_SAMPLE_FMT_FLT;
-            inputDepth = 4;
-            for (int i = 0; i < samples.length; i++) {
-                FloatBuffer b = (FloatBuffer)samples[i];
-                if (samples_in[i] instanceof FloatPointer && samples_in[i].capacity() >= inputSize && b.hasArray()) {
-                    ((FloatPointer)samples_in[i]).position(0).put(b.array(), b.position(), inputSize);
-                } else {
-                    if (samples_in[i] != null) {
-                        samples_in[i].releaseReference();
+            } else if (samples != null && samples[0] instanceof ShortBuffer) {
+                inputFormat = samples.length > 1 ? AV_SAMPLE_FMT_S16P : AV_SAMPLE_FMT_S16;
+                inputDepth = 2;
+                for (int i = 0; i < samples.length; i++) {
+                    ShortBuffer b = (ShortBuffer) samples[i];
+                    if (samples_in[i] instanceof ShortPointer && samples_in[i].capacity() >= inputSize && b.hasArray()) {
+                        ((ShortPointer) samples_in[i]).position(0).put(b.array(), samples[i].position(), inputSize);
+                    } else {
+                        if (samples_in[i] != null) {
+                            samples_in[i].releaseReference();
+                        }
+                        samples_in[i] = new ShortPointer(b).retainReference();
                     }
-                    samples_in[i] = new FloatPointer(b).retainReference();
                 }
-            }
-        } else if (samples != null && samples[0] instanceof DoubleBuffer) {
-            inputFormat = samples.length > 1 ? AV_SAMPLE_FMT_DBLP : AV_SAMPLE_FMT_DBL;
-            inputDepth = 8;
-            for (int i = 0; i < samples.length; i++) {
-                DoubleBuffer b = (DoubleBuffer)samples[i];
-                if (samples_in[i] instanceof DoublePointer && samples_in[i].capacity() >= inputSize && b.hasArray()) {
-                    ((DoublePointer)samples_in[i]).position(0).put(b.array(), b.position(), inputSize);
-                } else {
-                    if (samples_in[i] != null) {
-                        samples_in[i].releaseReference();
+            } else if (samples != null && samples[0] instanceof IntBuffer) {
+                inputFormat = samples.length > 1 ? AV_SAMPLE_FMT_S32P : AV_SAMPLE_FMT_S32;
+                inputDepth = 4;
+                for (int i = 0; i < samples.length; i++) {
+                    IntBuffer b = (IntBuffer) samples[i];
+                    if (samples_in[i] instanceof IntPointer && samples_in[i].capacity() >= inputSize && b.hasArray()) {
+                        ((IntPointer) samples_in[i]).position(0).put(b.array(), samples[i].position(), inputSize);
+                    } else {
+                        if (samples_in[i] != null) {
+                            samples_in[i].releaseReference();
+                        }
+                        samples_in[i] = new IntPointer(b).retainReference();
                     }
-                    samples_in[i] = new DoublePointer(b).retainReference();
                 }
+            } else if (samples != null && samples[0] instanceof FloatBuffer) {
+                inputFormat = samples.length > 1 ? AV_SAMPLE_FMT_FLTP : AV_SAMPLE_FMT_FLT;
+                inputDepth = 4;
+                for (int i = 0; i < samples.length; i++) {
+                    FloatBuffer b = (FloatBuffer) samples[i];
+                    if (samples_in[i] instanceof FloatPointer && samples_in[i].capacity() >= inputSize && b.hasArray()) {
+                        ((FloatPointer) samples_in[i]).position(0).put(b.array(), b.position(), inputSize);
+                    } else {
+                        if (samples_in[i] != null) {
+                            samples_in[i].releaseReference();
+                        }
+                        samples_in[i] = new FloatPointer(b).retainReference();
+                    }
+                }
+            } else if (samples != null && samples[0] instanceof DoubleBuffer) {
+                inputFormat = samples.length > 1 ? AV_SAMPLE_FMT_DBLP : AV_SAMPLE_FMT_DBL;
+                inputDepth = 8;
+                for (int i = 0; i < samples.length; i++) {
+                    DoubleBuffer b = (DoubleBuffer) samples[i];
+                    if (samples_in[i] instanceof DoublePointer && samples_in[i].capacity() >= inputSize && b.hasArray()) {
+                        ((DoublePointer) samples_in[i]).position(0).put(b.array(), b.position(), inputSize);
+                    } else {
+                        if (samples_in[i] != null) {
+                            samples_in[i].releaseReference();
+                        }
+                        samples_in[i] = new DoublePointer(b).retainReference();
+                    }
+                }
+            } else if (samples != null) {
+                throw new Exception("Audio samples Buffer has unsupported type: " + samples);
             }
-        } else if (samples != null) {
-            throw new Exception("Audio samples Buffer has unsupported type: " + samples);
-        }
 
-        if (samples_convert_ctx == null || samples_channels != audioChannels || samples_format != inputFormat || samples_rate != sampleRate) {
-            samples_convert_ctx = swr_alloc_set_opts(samples_convert_ctx, audio_c.channel_layout(), outputFormat, audio_c.sample_rate(),
-                    av_get_default_channel_layout(audioChannels), inputFormat, sampleRate, 0, null);
-            if (samples_convert_ctx == null) {
-                throw new Exception("swr_alloc_set_opts() error: Cannot allocate the conversion context.");
-            } else if ((ret = swr_init(samples_convert_ctx)) < 0) {
-                throw new Exception("swr_init() error " + ret + ": Cannot initialize the conversion context.");
+            if (samples_convert_ctx == null || samples_channels != audioChannels || samples_format != inputFormat || samples_rate != sampleRate) {
+                samples_convert_ctx = swr_alloc_set_opts(samples_convert_ctx, audio_c.channel_layout(), outputFormat, audio_c.sample_rate(),
+                        av_get_default_channel_layout(audioChannels), inputFormat, sampleRate, 0, null);
+                if (samples_convert_ctx == null) {
+                    throw new Exception("swr_alloc_set_opts() error: Cannot allocate the conversion context.");
+                } else if ((ret = swr_init(samples_convert_ctx)) < 0) {
+                    throw new Exception("swr_init() error " + ret + ": Cannot initialize the conversion context.");
+                }
+                samples_channels = audioChannels;
+                samples_format = inputFormat;
+                samples_rate = sampleRate;
             }
-            samples_channels = audioChannels;
-            samples_format = inputFormat;
-            samples_rate = sampleRate;
-        }
 
-        for (int i = 0; samples != null && i < samples.length; i++) {
-            samples_in[i].position(samples_in[i].position() * inputDepth).
-                    limit((samples_in[i].position() + inputSize) * inputDepth);
-        }
-        while (true) {
-            int inputCount = (int)Math.min(samples != null ? (samples_in[0].limit() - samples_in[0].position()) / (inputChannels * inputDepth) : 0, Integer.MAX_VALUE);
-            int outputCount = (int)Math.min((samples_out[0].limit() - samples_out[0].position()) / (outputChannels * outputDepth), Integer.MAX_VALUE);
-            inputCount = Math.min(inputCount, (outputCount * sampleRate + audio_c.sample_rate() - 1) / audio_c.sample_rate());
             for (int i = 0; samples != null && i < samples.length; i++) {
-                plane_ptr.put(i, samples_in[i]);
+                samples_in[i].position(samples_in[i].position() * inputDepth).
+                        limit((samples_in[i].position() + inputSize) * inputDepth);
             }
-            for (int i = 0; i < samples_out.length; i++) {
-                plane_ptr2.put(i, samples_out[i]);
-            }
-            if ((ret = swr_convert(samples_convert_ctx, plane_ptr2, outputCount, plane_ptr, inputCount)) < 0) {
-                throw new Exception("swr_convert() error " + ret + ": Cannot convert audio samples.");
-            } else if (ret == 0) {
-                break;
-            }
-            for (int i = 0; samples != null && i < samples.length; i++) {
-                samples_in[i].position(samples_in[i].position() + inputCount * inputChannels * inputDepth);
-            }
-            for (int i = 0; i < samples_out.length; i++) {
-                samples_out[i].position(samples_out[i].position() + ret * outputChannels * outputDepth);
-            }
+            while (true) {
+                int inputCount = (int) Math.min(samples != null ? (samples_in[0].limit() - samples_in[0].position()) / (inputChannels * inputDepth) : 0, Integer.MAX_VALUE);
+                int outputCount = (int) Math.min((samples_out[0].limit() - samples_out[0].position()) / (outputChannels * outputDepth), Integer.MAX_VALUE);
+                inputCount = Math.min(inputCount, (outputCount * sampleRate + audio_c.sample_rate() - 1) / audio_c.sample_rate());
+                for (int i = 0; samples != null && i < samples.length; i++) {
+                    plane_ptr.put(i, samples_in[i]);
+                }
+                for (int i = 0; i < samples_out.length; i++) {
+                    plane_ptr2.put(i, samples_out[i]);
+                }
+                if ((ret = swr_convert(samples_convert_ctx, plane_ptr2, outputCount, plane_ptr, inputCount)) < 0) {
+                    throw new Exception("swr_convert() error " + ret + ": Cannot convert audio samples.");
+                } else if (ret == 0) {
+                    break;
+                }
+                for (int i = 0; samples != null && i < samples.length; i++) {
+                    samples_in[i].position(samples_in[i].position() + inputCount * inputChannels * inputDepth);
+                }
+                for (int i = 0; i < samples_out.length; i++) {
+                    samples_out[i].position(samples_out[i].position() + ret * outputChannels * outputDepth);
+                }
 
-            if (samples == null || samples_out[0].position() >= samples_out[0].limit()) {
-                writeSamples(audio_input_frame_size);
+                if (samples == null || samples_out[0].position() >= samples_out[0].limit()) {
+                    writeSamples(audio_input_frame_size);
+                }
             }
-        }
-        return samples != null ? frame.key_frame() != 0 : writeFrame((AVFrame)null);
+            return samples != null ? frame.key_frame() != 0 : writeFrame((AVFrame) null);
 
         }
     }
@@ -1261,14 +1327,14 @@ public class FFmpegFrameRecorder extends FrameRecorder {
         }
 
         frame.nb_samples(nb_samples);
-        avcodec_fill_audio_frame(frame, audio_c.channels(), audio_c.sample_fmt(), samples_out[0], (int)samples_out[0].position(), 0);
+        avcodec_fill_audio_frame(frame, audio_c.channels(), audio_c.sample_fmt(), samples_out[0], (int) samples_out[0].position(), 0);
         for (int i = 0; i < samples_out.length; i++) {
             int linesize = 0;
             if (samples_out[0].position() > 0 && samples_out[0].position() < samples_out[0].limit()) {
                 // align the end of the buffer to a 32-byte boundary as sometimes required by FFmpeg
-                linesize = ((int)samples_out[i].position() + 31) & ~31;
+                linesize = ((int) samples_out[i].position() + 31) & ~31;
             } else {
-                linesize = (int)Math.min(samples_out[i].limit(), Integer.MAX_VALUE);
+                linesize = (int) Math.min(samples_out[i].limit(), Integer.MAX_VALUE);
             }
 
             frame.data(i, samples_out[i].position(0));
@@ -1314,7 +1380,7 @@ public class FFmpegFrameRecorder extends FrameRecorder {
             audio_pkt.stream_index(audio_st.index());
 
             /* write the compressed frame in the media file */
-            writePacket(AVMEDIA_TYPE_AUDIO, audio_pkt);
+            packetEncoded(AVMEDIA_TYPE_AUDIO, audio_pkt);
 
             if (frame == null) {
                 // avoid infinite loop with buggy codecs on flush
@@ -1346,6 +1412,21 @@ public class FFmpegFrameRecorder extends FrameRecorder {
         av_packet_unref(avPacket);
     }
 
+    /**
+     * Call encodedPacketHooker if set, and then write packet to output.
+     *
+     * @param mediaType media type, value is one of avutil.AVMEDIA_TYPE_XXXX
+     * @param avPacket the encoded packet which want to be written to output
+     *
+     * @throws Exception
+     */
+    private void packetEncoded(int mediaType, AVPacket avPacket) throws Exception {
+        if (encodedPacketHooker != null && (mediaType == AVMEDIA_TYPE_AUDIO || mediaType == AVMEDIA_TYPE_VIDEO))
+            encodedPacketHooker.onPacketEncoded(avPacket, mediaType == AVMEDIA_TYPE_AUDIO);
+
+        writePacket(mediaType, avPacket);
+    }
+
     public synchronized boolean recordPacket(AVPacket pkt) throws Exception {
         if (ifmt_ctx == null) {
             throw new Exception("No input format context (Has start(AVFormatContext) been called?)");
@@ -1370,15 +1451,15 @@ public class FFmpegFrameRecorder extends FrameRecorder {
         if (in_stream.codecpar().codec_type() == AVMEDIA_TYPE_VIDEO && video_st != null) {
             pkt.stream_index(video_st.index());
             pkt.duration((int) av_rescale_q(pkt.duration(), in_stream.time_base(), video_st.time_base()));
-            pkt.pts(av_rescale_q_rnd(pkt.pts(), in_stream.time_base(), video_st.time_base(),(AV_ROUND_NEAR_INF | AV_ROUND_PASS_MINMAX)));//Increase pts calculation
-            pkt.dts(av_rescale_q_rnd(pkt.dts(), in_stream.time_base(), video_st.time_base(),(AV_ROUND_NEAR_INF | AV_ROUND_PASS_MINMAX)));//Increase dts calculation
-            writePacket(AVMEDIA_TYPE_VIDEO, pkt);
+            pkt.pts(av_rescale_q_rnd(pkt.pts(), in_stream.time_base(), video_st.time_base(), (AV_ROUND_NEAR_INF | AV_ROUND_PASS_MINMAX)));//Increase pts calculation
+            pkt.dts(av_rescale_q_rnd(pkt.dts(), in_stream.time_base(), video_st.time_base(), (AV_ROUND_NEAR_INF | AV_ROUND_PASS_MINMAX)));//Increase dts calculation
+            packetEncoded(AVMEDIA_TYPE_VIDEO, pkt);
         } else if (in_stream.codecpar().codec_type() == AVMEDIA_TYPE_AUDIO && audio_st != null && (audioChannels > 0)) {
             pkt.stream_index(audio_st.index());
             pkt.duration((int) av_rescale_q(pkt.duration(), in_stream.time_base(), audio_st.time_base()));
-            pkt.pts(av_rescale_q_rnd(pkt.pts(), in_stream.time_base(), audio_st.time_base(),(AV_ROUND_NEAR_INF | AV_ROUND_PASS_MINMAX)));//Increase pts calculation
-            pkt.dts(av_rescale_q_rnd(pkt.dts(), in_stream.time_base(), audio_st.time_base(),(AV_ROUND_NEAR_INF | AV_ROUND_PASS_MINMAX)));//Increase dts calculation
-            writePacket(AVMEDIA_TYPE_AUDIO, pkt);
+            pkt.pts(av_rescale_q_rnd(pkt.pts(), in_stream.time_base(), audio_st.time_base(), (AV_ROUND_NEAR_INF | AV_ROUND_PASS_MINMAX)));//Increase pts calculation
+            pkt.dts(av_rescale_q_rnd(pkt.dts(), in_stream.time_base(), audio_st.time_base(), (AV_ROUND_NEAR_INF | AV_ROUND_PASS_MINMAX)));//Increase dts calculation
+            packetEncoded(AVMEDIA_TYPE_AUDIO, pkt);
         }
 
         return true;


### PR DESCRIPTION
Simply add an EncodedPacketHooker which will be called before each time FFmpegFrameRecorder write packet to the output, so the encoded packet raw data can be viewed and utilized by outside.