### PR TITLE
Modification of setFormat for VideoInputFrameGrabber

### DIFF
--- a/src/main/java/org/bytedeco/javacv/VideoInputFrameGrabber.java
+++ b/src/main/java/org/bytedeco/javacv/VideoInputFrameGrabber.java
@@ -105,6 +105,58 @@ public class VideoInputFrameGrabber extends FrameGrabber {
     }
     public void start(int connection) throws Exception {
         myVideoInput = new videoInput();
+	if (format != null && format.length() > 0) {
+		String formats[] = {"PAL_B", "PAL_D", "PAL_G", "PAL_H", "PAL_I", "PAL_M", "PAL_N", "PAL_NC",
+			"SECAM_B", "SECAM_D", "SECAM_G", "SECAM_H", "SECAM_K", "SECAM_K1", "SECAM_L",
+			"NTSC_M", "NTSC_M_J", "NTSC_433", };
+		String subTypes[] = {"RGB24", "RGB32", "RGB555", "RGB565", "YUY2", "YVYU", "YUYV", "IYUV", "UYVY",
+                                "YV12", "YVU9", "Y411", "Y41P", "Y211", "AYUV", "Y800", "Y8", "GREY", "MJPG"};
+      	        boolean settingFormat = Arrays.asList(formats).contains(format);
+            	boolean settingSubType = Arrays.asList(subTypes).contains(format);
+            	if (settingFormat) {
+                	int f = format.equals("NTSC_M")   ? VI_NTSC_M   :
+                        	format.equals("PAL_B")    ? VI_PAL_B    :
+                        	format.equals("PAL_D")    ? VI_PAL_D    :
+                        	format.equals("PAL_G")    ? VI_PAL_G    :
+                        	format.equals("PAL_H")    ? VI_PAL_H    :
+                        	format.equals("PAL_I")    ? VI_PAL_I    :
+                        	format.equals("PAL_M")    ? VI_PAL_M    :
+                        	format.equals("PAL_N")    ? VI_PAL_N    :
+                        format.equals("PAL_NC")   ? VI_PAL_NC   :
+                        format.equals("SECAM_B")  ? VI_SECAM_B  :
+                        format.equals("SECAM_D")  ? VI_SECAM_D  :
+                        format.equals("SECAM_G")  ? VI_SECAM_G  :
+                        format.equals("SECAM_H")  ? VI_SECAM_H  :
+                        format.equals("SECAM_K")  ? VI_SECAM_K  :
+                        format.equals("SECAM_K1") ? VI_SECAM_K1 :
+                        format.equals("SECAM_L")  ? VI_SECAM_L  :
+                        format.equals("NTSC_M_J") ? VI_NTSC_M_J :
+                        format.equals("NTSC_433") ? VI_NTSC_433 : -1;
+                myVideoInput.setFormat(deviceNumber, f);
+                if (f >= 0 && !myVideoInput.setFormat(deviceNumber, f)) {
+                    throw new Exception("videoInput.setFormat() Error: Could not set format " + format + ".");
+                }
+            } else if (settingSubType) {
+                int s = format.equals("RGB24")  ? VI_MEDIASUBTYPE_RGB24  :
+                        format.equals("RGB32")  ? VI_MEDIASUBTYPE_RGB32  :
+                        format.equals("RGB555") ? VI_MEDIASUBTYPE_RGB555 :
+                        format.equals("YUY2")   ? VI_MEDIASUBTYPE_YUY2   :
+                        format.equals("YVYU")   ? VI_MEDIASUBTYPE_YVYU   :
+                        format.equals("YUYV")   ? VI_MEDIASUBTYPE_YUYV   :
+                        format.equals("IYUV")   ? VI_MEDIASUBTYPE_IYUV   :
+                        format.equals("UYVY")   ? VI_MEDIASUBTYPE_UYVY   :
+                        format.equals("YV12")   ? VI_MEDIASUBTYPE_YV12   :
+                        format.equals("YVU9")   ? VI_MEDIASUBTYPE_YVU9   :
+                        format.equals("Y411")   ? VI_MEDIASUBTYPE_Y411   :
+                        format.equals("Y41P")   ? VI_MEDIASUBTYPE_Y41P   :
+                        format.equals("Y211")   ? VI_MEDIASUBTYPE_Y211   :
+                        format.equals("AYUV")   ? VI_MEDIASUBTYPE_AYUV   :
+                        format.equals("Y800")   ? VI_MEDIASUBTYPE_Y800   :
+                        format.equals("Y8")     ? VI_MEDIASUBTYPE_Y8     :
+                        format.equals("GREY")   ? VI_MEDIASUBTYPE_GREY   :
+                        format.equals("MJPG")   ? VI_MEDIASUBTYPE_MJPG   : -1;
+                myVideoInput.setRequestedMediaSubType(s);
+            }
         if (frameRate > 0) {
             myVideoInput.setIdealFramerate(deviceNumber, (int)frameRate);
         }
@@ -112,29 +164,6 @@ public class VideoInputFrameGrabber extends FrameGrabber {
                                                     imageHeight > 0 ? imageHeight : 480, connection)) {
             myVideoInput = null;
             throw new Exception("videoInput.setupDevice() Error: Could not setup device.");
-        }
-        if (format != null && format.length() > 0) {
-            int f = format.equals("VI_NTSC_M")   ? VI_NTSC_M   :
-                    format.equals("VI_PAL_B")    ? VI_PAL_B    :
-                    format.equals("VI_PAL_D")    ? VI_PAL_D    :
-                    format.equals("VI_PAL_G")    ? VI_PAL_G    :
-                    format.equals("VI_PAL_H")    ? VI_PAL_H    :
-                    format.equals("VI_PAL_I")    ? VI_PAL_I    :
-                    format.equals("VI_PAL_M")    ? VI_PAL_M    :
-                    format.equals("VI_PAL_N")    ? VI_PAL_N    :
-                    format.equals("VI_PAL_NC")   ? VI_PAL_NC   :
-                    format.equals("VI_SECAM_B")  ? VI_SECAM_B  :
-                    format.equals("VI_SECAM_D")  ? VI_SECAM_D  :
-                    format.equals("VI_SECAM_G")  ? VI_SECAM_G  :
-                    format.equals("VI_SECAM_H")  ? VI_SECAM_H  :
-                    format.equals("VI_SECAM_K")  ? VI_SECAM_K  :
-                    format.equals("VI_SECAM_K1") ? VI_SECAM_K1 :
-                    format.equals("VI_SECAM_L")  ? VI_SECAM_L  :
-                    format.equals("VI_NTSC_M_J") ? VI_NTSC_M_J :
-                    format.equals("VI_NTSC_433") ? VI_NTSC_433 : -1;
-            if (f >= 0 && !myVideoInput.setFormat(deviceNumber, f)) {
-                throw new Exception("videoInput.setFormat() Error: Could not set format " + format + ".");
-            }
         }
     }
 

--- a/src/main/java/org/bytedeco/javacv/VideoInputFrameGrabber.java
+++ b/src/main/java/org/bytedeco/javacv/VideoInputFrameGrabber.java
@@ -106,22 +106,22 @@ public class VideoInputFrameGrabber extends FrameGrabber {
     public void start(int connection) throws Exception {
         myVideoInput = new videoInput();
 	if (format != null && format.length() > 0) {
-		String formats[] = {"PAL_B", "PAL_D", "PAL_G", "PAL_H", "PAL_I", "PAL_M", "PAL_N", "PAL_NC",
-			"SECAM_B", "SECAM_D", "SECAM_G", "SECAM_H", "SECAM_K", "SECAM_K1", "SECAM_L",
-			"NTSC_M", "NTSC_M_J", "NTSC_433", };
-		String subTypes[] = {"RGB24", "RGB32", "RGB555", "RGB565", "YUY2", "YVYU", "YUYV", "IYUV", "UYVY",
-                                "YV12", "YVU9", "Y411", "Y41P", "Y211", "AYUV", "Y800", "Y8", "GREY", "MJPG"};
-      	        boolean settingFormat = Arrays.asList(formats).contains(format);
-            	boolean settingSubType = Arrays.asList(subTypes).contains(format);
-            	if (settingFormat) {
-                	int f = format.equals("NTSC_M")   ? VI_NTSC_M   :
-                        	format.equals("PAL_B")    ? VI_PAL_B    :
-                        	format.equals("PAL_D")    ? VI_PAL_D    :
-                        	format.equals("PAL_G")    ? VI_PAL_G    :
-                        	format.equals("PAL_H")    ? VI_PAL_H    :
-                        	format.equals("PAL_I")    ? VI_PAL_I    :
-                        	format.equals("PAL_M")    ? VI_PAL_M    :
-                        	format.equals("PAL_N")    ? VI_PAL_N    :
+	    String formats[] = {"PAL_B", "PAL_D", "PAL_G", "PAL_H", "PAL_I", "PAL_M", "PAL_N", "PAL_NC",
+				"SECAM_B", "SECAM_D", "SECAM_G", "SECAM_H", "SECAM_K", "SECAM_K1", "SECAM_L",
+				"NTSC_M", "NTSC_M_J", "NTSC_433", };
+	    String subTypes[] = {"RGB24", "RGB32", "RGB555", "RGB565", "YUY2", "YVYU", "YUYV", "IYUV", "UYVY",
+                                 "YV12", "YVU9", "Y411", "Y41P", "Y211", "AYUV", "Y800", "Y8", "GREY", "MJPG"};
+      	    boolean settingFormat = Arrays.asList(formats).contains(format);
+            boolean settingSubType = Arrays.asList(subTypes).contains(format);
+            if (settingFormat) {
+                int f = format.equals("NTSC_M")   ? VI_NTSC_M   :
+                        format.equals("PAL_B")    ? VI_PAL_B    :
+                        format.equals("PAL_D")    ? VI_PAL_D    :
+                	format.equals("PAL_G")    ? VI_PAL_G    :
+                	format.equals("PAL_H")    ? VI_PAL_H    :
+                	format.equals("PAL_I")    ? VI_PAL_I    :
+                        format.equals("PAL_M")    ? VI_PAL_M    :
+                        format.equals("PAL_N")    ? VI_PAL_N    :
                         format.equals("PAL_NC")   ? VI_PAL_NC   :
                         format.equals("SECAM_B")  ? VI_SECAM_B  :
                         format.equals("SECAM_D")  ? VI_SECAM_D  :
@@ -133,8 +133,8 @@ public class VideoInputFrameGrabber extends FrameGrabber {
                         format.equals("NTSC_M_J") ? VI_NTSC_M_J :
                         format.equals("NTSC_433") ? VI_NTSC_433 : -1;
                 myVideoInput.setFormat(deviceNumber, f);
-                if (f >= 0 && !myVideoInput.setFormat(deviceNumber, f)) {
-                    throw new Exception("videoInput.setFormat() Error: Could not set format " + format + ".");
+	        if (f >= 0 && !myVideoInput.setFormat(deviceNumber, f)) {
+	            throw new Exception("videoInput.setFormat() Error: Could not set format " + format + ".");
                 }
             } else if (settingSubType) {
                 int s = format.equals("RGB24")  ? VI_MEDIASUBTYPE_RGB24  :
@@ -157,6 +157,7 @@ public class VideoInputFrameGrabber extends FrameGrabber {
                         format.equals("MJPG")   ? VI_MEDIASUBTYPE_MJPG   : -1;
                 myVideoInput.setRequestedMediaSubType(s);
             }
+	}
         if (frameRate > 0) {
             myVideoInput.setIdealFramerate(deviceNumber, (int)frameRate);
         }


### PR DESCRIPTION
Since the current implementation of `VideoInputFrameGrabber` does nothing, I modified the statements inside the `start()` method of the class. In this change, developers can now set the format/subtype of that FrameGrabber. They can now use MJPEG instead of the default media format.