### PR TITLE
bugfix memory leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 
+ * Fix memory leak in `FFmpegFrameGrabber` when decoding from `InputStream` ([pull #2214](https://github.com/bytedeco/javacv/pull/2214))
  * Upgrade dependencies for FFmpeg 7.0
 
 ### January 29, 2024 version 1.5.10

--- a/src/main/java/org/bytedeco/javacv/FFmpegFrameGrabber.java
+++ b/src/main/java/org/bytedeco/javacv/FFmpegFrameGrabber.java
@@ -280,7 +280,7 @@ public class FFmpegFrameGrabber extends FrameGrabber {
                     avio = null;
                 }
                 if (oc != null) {
-                    avformat_free_context(oc);
+                    avformat_close_input(oc);
                     oc = null;
                 }
             }


### PR DESCRIPTION
This is the solution for the issue https://github.com/bytedeco/javacv/issues/2119
When release AVFormatContext use avformat_close_input instead of avformat_free_context.
