### PR TITLE
[fix] filter: add args modify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 
+ * Add `FrameFilter.videoFilterArgs/audioFilterArgs` properties to support multiple different inputs ([pull #2304](https://github.com/bytedeco/javacv/pull/2304))
  * Ensure `FFmpegFrameGrabber.start()` skips over streams with no codecs ([issue #2299](https://github.com/bytedeco/javacv/issues/2299))
  * Add `FFmpegLogCallback.logRejectedOptions()` for debugging purposes ([pull #2301](https://github.com/bytedeco/javacv/pull/2301))
 

--- a/src/main/java/org/bytedeco/javacv/FFmpegFrameFilter.java
+++ b/src/main/java/org/bytedeco/javacv/FFmpegFrameFilter.java
@@ -358,7 +358,7 @@ public class FFmpegFrameFilter extends FrameFilter {
                         : String.format(Locale.ROOT, "video_size=%dx%d:pix_fmt=%d:time_base=%d/%d:pixel_aspect=%d/%d:frame_rate=%d/%d",
                                imageWidth, imageHeight, pixelFormat, time_base.num(), time_base.den(), r.num(), r.den(), frame_rate.num(), frame_rate.den());
                 ret = avfilter_graph_create_filter(buffersrc_ctx[i] = new AVFilterContext().retainReference(), buffersrc, name,
-                        args, null, filter_graph);
+                                                   args, null, filter_graph);
                 if (ret < 0) {
                     throw new Exception("avfilter_graph_create_filter() error " + ret + ": Cannot create video buffer source.");
                 }

--- a/src/main/java/org/bytedeco/javacv/FFmpegFrameFilter.java
+++ b/src/main/java/org/bytedeco/javacv/FFmpegFrameFilter.java
@@ -308,10 +308,10 @@ public class FFmpegFrameFilter extends FrameFilter {
         frame = new Frame();
         default_layout = new AVChannelLayout().retainReference();
 
-        if (videoFilterArgs!=null && videoInputs!=videoFilterArgs.length){
+        if (videoFilterArgs != null && videoInputs != videoFilterArgs.length) {
             throw new Exception("The length of videoFilterArgs is different from videoInputs");
         }
-        if (audioFilterArgs!=null && audioInputs!=audioFilterArgs.length){
+        if (audioFilterArgs != null && audioInputs != audioFilterArgs.length) {
             throw new Exception("The length of audioFilterArgs is different from audioInputs");
         }
         if (image_frame == null || samples_frame == null || filt_frame == null) {
@@ -348,15 +348,15 @@ public class FFmpegFrameFilter extends FrameFilter {
 
             /* buffer video source: the decoded frames from the decoder will be inserted here. */
             AVRational r = av_d2q(aspectRatio > 0 ? aspectRatio : 1, 255);
-            String argsBase = String.format(Locale.ROOT, "video_size=%dx%d:pix_fmt=%d:time_base=%d/%d:pixel_aspect=%d/%d:frame_rate=%d/%d",
-                    imageWidth, imageHeight, pixelFormat, time_base.num(), time_base.den(), r.num(), r.den(), frame_rate.num(), frame_rate.den());
             buffersrc_ctx = new AVFilterContext[videoInputs];
             setpts_ctx = new AVFilterContext[videoInputs];
             for (int i = 0; i < videoInputs; i++) {
                 String name = videoInputs > 1 ? i + ":v" : "in";
                 outputs[i] = avfilter_inout_alloc();
 
-                String args=videoFilterArgs!=null && videoFilterArgs[i]!=null ? videoFilterArgs[i]:argsBase;
+                String args = videoFilterArgs != null && videoFilterArgs[i] != null ? videoFilterArgs[i]
+                        : String.format(Locale.ROOT, "video_size=%dx%d:pix_fmt=%d:time_base=%d/%d:pixel_aspect=%d/%d:frame_rate=%d/%d",
+                               imageWidth, imageHeight, pixelFormat, time_base.num(), time_base.den(), r.num(), r.den(), frame_rate.num(), frame_rate.den());
                 ret = avfilter_graph_create_filter(buffersrc_ctx[i] = new AVFilterContext().retainReference(), buffersrc, name,
                         args, null, filter_graph);
                 if (ret < 0) {
@@ -454,8 +454,9 @@ public class FFmpegFrameFilter extends FrameFilter {
 
                 /* buffer audio source: the decoded frames from the decoder will be inserted here. */
                 av_channel_layout_default(default_layout, audioChannels);
-                String aargs = audioFilterArgs!=null && audioFilterArgs[i]!=null ?audioFilterArgs[i]:String.format(Locale.ROOT, "channels=%d:sample_fmt=%d:sample_rate=%d:channel_layout=%d",
-                        audioChannels, sampleFormat, sampleRate, default_layout.u_mask());
+                String aargs = audioFilterArgs != null && audioFilterArgs[i] != null ? audioFilterArgs[i]
+                        : String.format(Locale.ROOT, "channels=%d:sample_fmt=%d:sample_rate=%d:channel_layout=%d",
+                                audioChannels, sampleFormat, sampleRate, default_layout.u_mask());
                 ret = avfilter_graph_create_filter(abuffersrc_ctx[i] = new AVFilterContext().retainReference(), abuffersrc, name,
                                                    aargs, null, afilter_graph);
                 if (ret < 0) {

--- a/src/main/java/org/bytedeco/javacv/FFmpegFrameFilter.java
+++ b/src/main/java/org/bytedeco/javacv/FFmpegFrameFilter.java
@@ -54,7 +54,9 @@ import java.nio.DoubleBuffer;
 import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
 import java.nio.ShortBuffer;
+import java.util.Arrays;
 import java.util.Locale;
+
 import org.bytedeco.javacpp.BytePointer;
 import org.bytedeco.javacpp.DoublePointer;
 import org.bytedeco.javacpp.FloatPointer;
@@ -89,6 +91,13 @@ public class FFmpegFrameFilter extends FrameFilter {
         public Exception(String message) { super(message + " (For more details, make sure FFmpegLogCallback.set() has been called.)"); }
         public Exception(String message, Throwable cause) { super(message, cause); }
     }
+
+    public static interface InputArgsGenerate {
+        public String generateArgs(int i,Object[] argCopy,String template);
+    }
+
+    private InputArgsGenerate videoInputArgsGenerate;
+    private InputArgsGenerate audioInputArgsGenerate;
 
     private static Exception loadingException = null;
     public static void tryLoad() throws Exception {
@@ -342,16 +351,22 @@ public class FFmpegFrameFilter extends FrameFilter {
 
             /* buffer video source: the decoded frames from the decoder will be inserted here. */
             AVRational r = av_d2q(aspectRatio > 0 ? aspectRatio : 1, 255);
-            String args = String.format(Locale.ROOT, "video_size=%dx%d:pix_fmt=%d:time_base=%d/%d:pixel_aspect=%d/%d:frame_rate=%d/%d",
-                    imageWidth, imageHeight, pixelFormat, time_base.num(), time_base.den(), r.num(), r.den(), frame_rate.num(), frame_rate.den());
+            Object[] argList=new Object[]{imageWidth,imageHeight,pixelFormat,time_base.num(),time_base.den(),r.num(), r.den(), frame_rate.num(), frame_rate.den()};
+            String argsTemplate="video_size=%dx%d:pix_fmt=%d:time_base=%d/%d:pixel_aspect=%d/%d:frame_rate=%d/%d";
+            String args = String.format(Locale.ROOT, argsTemplate, argList);
+
             buffersrc_ctx = new AVFilterContext[videoInputs];
             setpts_ctx = new AVFilterContext[videoInputs];
             for (int i = 0; i < videoInputs; i++) {
                 String name = videoInputs > 1 ? i + ":v" : "in";
                 outputs[i] = avfilter_inout_alloc();
+                String realArgs=args;
+                if (this.videoInputArgsGenerate!=null){
+                    realArgs=this.videoInputArgsGenerate.generateArgs(i, Arrays.copyOf(argList,argList.length),argsTemplate);
+                }
 
                 ret = avfilter_graph_create_filter(buffersrc_ctx[i] = new AVFilterContext().retainReference(), buffersrc, name,
-                                                   args, null, filter_graph);
+                        realArgs, null, filter_graph);
                 if (ret < 0) {
                     throw new Exception("avfilter_graph_create_filter() error " + ret + ": Cannot create video buffer source.");
                 }
@@ -441,14 +456,20 @@ public class FFmpegFrameFilter extends FrameFilter {
 
             abuffersrc_ctx = new AVFilterContext[audioInputs];
             asetpts_ctx = new AVFilterContext[audioInputs];
+            String argsTemplate="channels=%d:sample_fmt=%d:sample_rate=%d:channel_layout=%d";
             for (int i = 0; i < audioInputs; i++) {
                 String name = audioInputs > 1 ? i + ":a" : "in";
                 aoutputs[i] = avfilter_inout_alloc();
 
                 /* buffer audio source: the decoded frames from the decoder will be inserted here. */
                 av_channel_layout_default(default_layout, audioChannels);
-                String aargs = String.format(Locale.ROOT, "channels=%d:sample_fmt=%d:sample_rate=%d:channel_layout=%d",
-                        audioChannels, sampleFormat, sampleRate, default_layout.u_mask());
+                Object[] argList=new Object[]{audioChannels, sampleFormat, sampleRate, default_layout.u_mask()};
+                String aargs = String.format(Locale.ROOT,argsTemplate,argList);
+
+                if (this.audioInputArgsGenerate!=null){
+                    aargs=this.audioInputArgsGenerate.generateArgs(i,Arrays.copyOf(argList,argList.length),argsTemplate);
+                }
+
                 ret = avfilter_graph_create_filter(abuffersrc_ctx[i] = new AVFilterContext().retainReference(), abuffersrc, name,
                                                    aargs, null, afilter_graph);
                 if (ret < 0) {
@@ -814,5 +835,13 @@ public class FFmpegFrameFilter extends FrameFilter {
         return frame;
 
         }
+    }
+
+    public void setVideoInputArgsGenerate(InputArgsGenerate videoInputArgsGenerate) {
+        this.videoInputArgsGenerate = videoInputArgsGenerate;
+    }
+
+    public void setAudioInputArgsGenerate(InputArgsGenerate audioInputArgsGenerate) {
+        this.audioInputArgsGenerate = audioInputArgsGenerate;
     }
 }

--- a/src/main/java/org/bytedeco/javacv/FrameFilter.java
+++ b/src/main/java/org/bytedeco/javacv/FrameFilter.java
@@ -49,6 +49,8 @@ public abstract class FrameFilter implements Closeable {
     protected int sampleFormat;
     protected int sampleRate;
     protected int audioInputs;
+    protected String[] videoFilterArgs ;
+    protected String[] audioFilterArgs ;
 
     public String getFilters() {
         return filters;
@@ -125,6 +127,22 @@ public abstract class FrameFilter implements Closeable {
     }
     public void setAudioInputs(int audioInputs) {
         this.audioInputs = audioInputs;
+    }
+
+    public String[] getVideoFilterArgs() {
+        return videoFilterArgs;
+    }
+
+    public void setVideoFilterArgs(String[] videoFilterArgs) {
+        this.videoFilterArgs = videoFilterArgs;
+    }
+
+    public String[] getAudioFilterArgs() {
+        return audioFilterArgs;
+    }
+
+    public void setAudioFilterArgs(String[] audioFilterArgs) {
+        this.audioFilterArgs = audioFilterArgs;
     }
 
     public static class Exception extends IOException {

--- a/src/main/java/org/bytedeco/javacv/FrameFilter.java
+++ b/src/main/java/org/bytedeco/javacv/FrameFilter.java
@@ -43,14 +43,14 @@ public abstract class FrameFilter implements Closeable {
     protected double frameRate;
     protected double aspectRatio;
     protected int videoInputs;
+    protected String[] videoFilterArgs;
 
     protected String afilters;
     protected int audioChannels;
     protected int sampleFormat;
     protected int sampleRate;
     protected int audioInputs;
-    protected String[] videoFilterArgs ;
-    protected String[] audioFilterArgs ;
+    protected String[] audioFilterArgs;
 
     public String getFilters() {
         return filters;
@@ -101,6 +101,14 @@ public abstract class FrameFilter implements Closeable {
         this.videoInputs = videoInputs;
     }
 
+    public String[] getVideoFilterArgs() {
+        return videoFilterArgs;
+    }
+
+    public void setVideoFilterArgs(String[] videoFilterArgs) {
+        this.videoFilterArgs = videoFilterArgs;
+    }
+
     public int getAudioChannels() {
         return audioChannels;
     }
@@ -127,14 +135,6 @@ public abstract class FrameFilter implements Closeable {
     }
     public void setAudioInputs(int audioInputs) {
         this.audioInputs = audioInputs;
-    }
-
-    public String[] getVideoFilterArgs() {
-        return videoFilterArgs;
-    }
-
-    public void setVideoFilterArgs(String[] videoFilterArgs) {
-        this.videoFilterArgs = videoFilterArgs;
     }
 
     public String[] getAudioFilterArgs() {


### PR DESCRIPTION
Recently, I created an overlay filter and found that the size of each input and pixelFormat cannot be customized, resulting in incorrect output video. Therefore, I added the following code, which can be modified after the original configuration is generated.