### PR TITLE
#2074 Fix dropped frames at the end of encoders that buffer more than one packet.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 
+ * Fix `FFmpegFrameRecorder` dropped frame issues with audio samples ([pull #2307](https://github.com/bytedeco/javacv/pull/2307))
  * Add `FrameFilter.videoFilterArgs/audioFilterArgs` properties to support multiple different inputs ([pull #2304](https://github.com/bytedeco/javacv/pull/2304))
  * Ensure `FFmpegFrameGrabber.start()` skips over streams with no codecs ([issue #2299](https://github.com/bytedeco/javacv/issues/2299))
  * Add `FFmpegLogCallback.logRejectedOptions()` for debugging purposes ([pull #2301](https://github.com/bytedeco/javacv/pull/2301))

--- a/platform/src/test/java/org/bytedeco/javacv/FrameFilterTest.java
+++ b/platform/src/test/java/org/bytedeco/javacv/FrameFilterTest.java
@@ -199,9 +199,9 @@ public class FrameFilterTest {
                         d++;
                         assertEquals(4, frame3.audioChannels);
                         assertEquals(1, frame3.samples.length);
-                        assertTrue(frame3.samples[0] instanceof ByteBuffer);
+                        assertTrue(frame3.samples[0] instanceof ShortBuffer);
                         assertEquals(frame2.samples.length, frame3.samples.length);
-                        assertEquals(frame2.samples[0].limit(), frame3.samples[0].limit());
+                        assertEquals(2 * frame2.samples[0].limit(), frame3.samples[0].limit());
                     }
                 }
             }

--- a/platform/src/test/java/org/bytedeco/javacv/FrameFilterTest.java
+++ b/platform/src/test/java/org/bytedeco/javacv/FrameFilterTest.java
@@ -197,7 +197,7 @@ public class FrameFilterTest {
                     }
                     if (frame3.samples != null) {
                         d++;
-                        assertEquals(2, frame3.audioChannels);
+                        assertEquals(4, frame3.audioChannels);
                         assertEquals(1, frame3.samples.length);
                         assertTrue(frame3.samples[0] instanceof ByteBuffer);
                         assertEquals(frame2.samples.length, frame3.samples.length);

--- a/src/main/java/org/bytedeco/javacv/FFmpegFrameRecorder.java
+++ b/src/main/java/org/bytedeco/javacv/FFmpegFrameRecorder.java
@@ -1284,7 +1284,6 @@ public class FFmpegFrameRecorder extends FrameRecorder {
                     limit((samples_in[i].position() + inputSize) * inputDepth);
         }
         while (true) {
-            // TODO: We're dropping any samples that don't fit into the sample size. We might want to pad instead.
             int inputCount = (int)Math.min(samples != null ? (samples_in[0].limit() - samples_in[0].position()) / (inputChannels * inputDepth) : 0, Integer.MAX_VALUE);
             int outputCount = (int)Math.min((samples_out[0].limit() - samples_out[0].position()) / (outputChannels * outputDepth), Integer.MAX_VALUE);
             inputCount = Math.min(inputCount, (outputCount * sampleRate + audio_c.sample_rate() - 1) / audio_c.sample_rate());

--- a/src/main/java/org/bytedeco/javacv/FFmpegFrameRecorder.java
+++ b/src/main/java/org/bytedeco/javacv/FFmpegFrameRecorder.java
@@ -1170,13 +1170,6 @@ public class FFmpegFrameRecorder extends FrameRecorder {
             throw new Exception("start() was not called successfully!");
         }
 
-        if (samples == null && samples_out[0].position() > 0) {
-            // Typically samples_out[0].limit() is double the audio_input_frame_size --> sampleDivisor = 2
-            double sampleDivisor = Math.floor((int)Math.min(samples_out[0].limit(), Integer.MAX_VALUE) / audio_input_frame_size);
-            writeSamples((int)Math.floor((int)samples_out[0].position() / sampleDivisor));
-            return writeFrame((AVFrame)null);
-        }
-
         if (samples == null && samples_convert_ctx == null) {
             // We haven't tried to record any samples yet so we don't need to flush.
             return false;
@@ -1322,6 +1315,14 @@ public class FFmpegFrameRecorder extends FrameRecorder {
                 writeSamples(audio_input_frame_size);
             }
         }
+
+        if (samples == null && samples_out[0].position() > 0) {
+            // Typically samples_out[0].limit() is double the audio_input_frame_size --> sampleDivisor = 2
+            double sampleDivisor = Math.floor((int)Math.min(samples_out[0].limit(), Integer.MAX_VALUE) / audio_input_frame_size);
+            writeSamples((int)Math.floor((int)samples_out[0].position() / sampleDivisor));
+            return writeFrame((AVFrame)null);
+        }
+
         return samples != null ? frame.key_frame() != 0 : writeFrame((AVFrame)null);
 
         }

--- a/src/main/java/org/bytedeco/javacv/FFmpegFrameRecorder.java
+++ b/src/main/java/org/bytedeco/javacv/FFmpegFrameRecorder.java
@@ -1350,6 +1350,8 @@ public class FFmpegFrameRecorder extends FrameRecorder {
             frame.pts(frame.pts() + frame.nb_samples()); // magic required by libvorbis and webm
         }
 
+        int retries = 0;
+        int maxRetries = 1000;
         /* if zero size, it means the image was buffered */
         got_audio_packet[0] = 0;
         while (ret >= 0) {
@@ -1376,7 +1378,7 @@ public class FFmpegFrameRecorder extends FrameRecorder {
             /* write the compressed frame in the media file */
             writePacket(AVMEDIA_TYPE_AUDIO, audio_pkt);
 
-            if (frame == null) {
+            if (frame == null && retries++ > maxRetries) {
                 // avoid infinite loop with buggy codecs on flush
                 break;
             }

--- a/src/main/java/org/bytedeco/javacv/FFmpegFrameRecorder.java
+++ b/src/main/java/org/bytedeco/javacv/FFmpegFrameRecorder.java
@@ -1350,8 +1350,6 @@ public class FFmpegFrameRecorder extends FrameRecorder {
             frame.pts(frame.pts() + frame.nb_samples()); // magic required by libvorbis and webm
         }
 
-        int retries = 0;
-        int maxRetries = 1000;
         /* if zero size, it means the image was buffered */
         got_audio_packet[0] = 0;
         while (ret >= 0) {
@@ -1378,7 +1376,7 @@ public class FFmpegFrameRecorder extends FrameRecorder {
             /* write the compressed frame in the media file */
             writePacket(AVMEDIA_TYPE_AUDIO, audio_pkt);
 
-            if (frame == null && retries++ > maxRetries) {
+            if (frame == null) {
                 // avoid infinite loop with buggy codecs on flush
                 break;
             }


### PR DESCRIPTION
Fix for #2074. Add a retry mechanism. The test that was modified was asserting incorrectly, since the expected amerge behavior is to add the channels to the file if both the input files are stereo. 