### PR TITLE
Update badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@ JavaCV
 ======
 
 [![Gitter](https://badges.gitter.im/bytedeco/javacv.svg)](https://gitter.im/bytedeco/javacv)
-![Maven Central Version](https://img.shields.io/maven-central/v/org.bytedeco/javacv?label=maven-central%20%28jacacv%29)
-![Maven Central Version (Snapshots)](https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Fcentral.sonatype.com%2Frepository%2Fmaven-snapshots%2Forg%2Fbytedeco%2Fjavacv%2Fmaven-metadata.xml&label=maven-central-snapshot%20%28jacacv%29)
-![Maven Central Version](https://img.shields.io/maven-central/v/org.bytedeco/javacv-platform?label=maven-central%20%28jacacv-platform%29)
-![Maven Central Version (Snapshots)](https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Fcentral.sonatype.com%2Frepository%2Fmaven-snapshots%2Forg%2Fbytedeco%2Fjavacv-platform%2Fmaven-metadata.xml&label=maven-central-snapshot%20%28jacacv-platform%29)
+![Maven Central Version](https://img.shields.io/maven-central/v/org.bytedeco/javacv?label=maven-central%20%28javacv%29)
+![Maven Central Version (Snapshots)](https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Fcentral.sonatype.com%2Frepository%2Fmaven-snapshots%2Forg%2Fbytedeco%2Fjavacv%2Fmaven-metadata.xml&label=maven-central-snapshot%20%28javacv%29)
+![Maven Central Version](https://img.shields.io/maven-central/v/org.bytedeco/javacv-platform?label=maven-central%20%28javacv-platform%29)
+![Maven Central Version (Snapshots)](https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Fcentral.sonatype.com%2Frepository%2Fmaven-snapshots%2Forg%2Fbytedeco%2Fjavacv-platform%2Fmaven-metadata.xml&label=maven-central-snapshot%20%28javacv-platform%29)
 
 Introduction
 ------------


### PR DESCRIPTION
Updating badges to show correct versions. Also showing both `javacv` as `javacv-platform`.
<img width="1178" height="209" alt="image" src="https://github.com/user-attachments/assets/96e55e79-02b0-40aa-8733-58206a5057a8" />

The Maven Central version is correct; at moment of writing it is indeed `v1.5.12`. However, the current snapshot version should be `v1.5.13-SNAPSHOT`, but this isn't the case. This is likely due to the end-of-life of OSSRH, the used Nexus repository in this case.

When I tested locally, `v1.5.13-SNAPSHOT` was available for `javacv` on https://central.sonatype.com/repository/maven-snapshots/, the new location for snapshot packages on Maven Central. However, `javacv-platform` didn't have a snapshot yet. Is this correct?